### PR TITLE
feat: WMP-028 persist the consumed assets 

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/AlertAssetProvider.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/AlertAssetProvider.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.intellij.util.ResourceUtil;
 import org.jetbrains.annotations.NonNls;
+import zd.zero.waifu.motivator.plugin.providers.UniqueValueProvider;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,7 +14,13 @@ import java.util.stream.Stream;
 
 public class AlertAssetProvider {
 
+    private static final String USED_ALERTS = "WMP_USED_ALERTS";
+
     private static WaifuMotivatorAlertAsset[] alertAssets;
+
+    private static UniqueValueProvider<WaifuMotivatorAlertAsset> uniqueProvider;
+
+    private static Random random;
 
     private AlertAssetProvider() {
         throw new AssertionError( "Never instantiate." );
@@ -29,8 +36,22 @@ public class AlertAssetProvider {
                     .toArray( WaifuMotivatorAlertAsset[]::new );
         }
 
-        int randomIndex = new Random().nextInt( assets.length );
-        return assets[randomIndex];
+        if ( uniqueProvider == null ) {
+            uniqueProvider = new UniqueValueProvider<>( USED_ALERTS, assets );
+        }
+        WaifuMotivatorAlertAsset[] filteredAlerts = uniqueProvider.getUniqueValues( WaifuMotivatorAlertAsset::getTitle ).toArray( new WaifuMotivatorAlertAsset[0] );
+
+        WaifuMotivatorAlertAsset asset;
+        if ( filteredAlerts.length == 1 ) {
+            asset = filteredAlerts[0];
+        } else {
+            random = random == null ? new Random() : random;
+            int randomIndex = random.nextInt( filteredAlerts.length );
+            asset = filteredAlerts[randomIndex];
+        }
+        uniqueProvider.addToSeenValues( asset.getTitle() );
+
+        return asset;
     }
 
     private static WaifuMotivatorAlertAsset[] getWaifuMotivatorAlertAssets() {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/providers/UniqueValueProvider.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/providers/UniqueValueProvider.java
@@ -1,0 +1,47 @@
+package zd.zero.waifu.motivator.plugin.providers;
+
+import com.intellij.ide.util.PropertiesComponent;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toList;
+
+public class UniqueValueProvider<T> {
+
+    private final String PROPERTY_KEY;
+
+    private T[] initialValues;
+
+    private String lastSeenValue = "";
+
+    public UniqueValueProvider( final String PROPERTY_KEY, T[] initialValues ) {
+        this.PROPERTY_KEY = PROPERTY_KEY;
+        this.initialValues = initialValues;
+    }
+
+    public List<T> getUniqueValues( Function<T, String> function ) {
+        String[] usedKeyValues = getValue().split( "\\|" );
+
+        List<T> filteredValues = Arrays.stream( initialValues )
+                .filter( v -> !Arrays.asList( usedKeyValues ).contains( function.apply( v ) ) ).collect( toList() );
+
+        if ( filteredValues.isEmpty() ) {
+            filteredValues = Arrays.stream( initialValues )
+                    .filter( v -> !function.apply( v ).equals( lastSeenValue ) ).collect( toList() );
+            PropertiesComponent.getInstance().setValue( PROPERTY_KEY, "" );
+        }
+
+        return filteredValues;
+    }
+
+    public void addToSeenValues( String seenValue ) {
+        this.lastSeenValue = seenValue;
+        PropertiesComponent.getInstance().setValue( PROPERTY_KEY, getValue() + "|" + seenValue );
+    }
+
+    private String getValue() {
+        return PropertiesComponent.getInstance().getValue( PROPERTY_KEY, "" );
+    }
+}


### PR DESCRIPTION
Persist the consumed assets to not play until all of it are consumed. This implementation improved the way how WMP alerts and shows Waifu of the Day to avoid repeating the content.

Resolves #28 