### PR TITLE
bug: WMP-042 resolve sound stopping when the alert is expired

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/WaifuMotivatorAlert.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/WaifuMotivatorAlert.java
@@ -1,5 +1,7 @@
 package zd.zero.waifu.motivator.plugin.alert;
 
+import com.intellij.notification.Notification;
+
 public interface WaifuMotivatorAlert {
 
     boolean isDisplayNotificationEnabled();
@@ -12,7 +14,7 @@ public interface WaifuMotivatorAlert {
 
     boolean isAlertEnabled();
 
-    void onAlertClosed();
+    void onAlertClosed( Notification notification );
 
     default void alert() {
         if ( isAlertEnabled() ) {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/WaifuMotivatorAlertImpl.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/WaifuMotivatorAlertImpl.java
@@ -33,8 +33,12 @@ public class WaifuMotivatorAlertImpl implements WaifuMotivatorAlert {
     }
 
     @Override
-    public void onAlertClosed() {
-        player.stop();
+    public void onAlertClosed( Notification notification ) {
+        long duration = System.currentTimeMillis() - notification.getTimestamp();
+        boolean isExpired = ( duration / 1000 ) >= 10;
+        if ( !isExpired ) {
+            player.stop();
+        }
     }
 
     @Override
@@ -47,7 +51,7 @@ public class WaifuMotivatorAlertImpl implements WaifuMotivatorAlert {
             balloon.addListener( new JBPopupListener() {
                 @Override
                 public void onClosed( @NotNull LightweightWindowEvent event ) {
-                    onAlertClosed();
+                    onAlertClosed( notification );
                 }
             } );
         }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/notification/WaifuMotivatorNotifier.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/notification/WaifuMotivatorNotifier.java
@@ -16,7 +16,7 @@ public interface WaifuMotivatorNotifier {
 
     default Notification createNotification() {
         NotificationGroup notificationGroup = new NotificationGroup(
-                WaifuMotivator.PLUGIN_ID, NotificationDisplayType.BALLOON, false
+                WaifuMotivator.PLUGIN_NAME, NotificationDisplayType.BALLOON, false
         );
 
         return notificationGroup.createNotification()


### PR DESCRIPTION
The `Notification#isExpired` is always called even if the user clicked the close notification, so I needed to compute the average duration of the Notification to tell whether it already expired or not and the Notification usually closes at `10s`, the duration sometimes goes up to `10s` to `13s` and the minimum value is the `10s` as a safe bet we used it to the condition, the reason why it doesn't have a prefix duration because disposing the Notification is requested to the Event Dispatch Thread (EDT) and not executed immediately.

Resolves #42 