### PR TITLE
chore: bump idea support version to 2020.1

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -14,6 +14,7 @@
     <bytecodeTargetLevel>
       <module name="waifu-motivator-plugin.main" target="1.8" />
       <module name="waifu-motivator-plugin.test" target="1.8" />
+      <module name="zd-zero.waifu-motivator-plugin" target="1.8" />
     </bytecodeTargetLevel>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="FrameworkDetectionExcludesConfiguration">
+    <file type="web" url="file://$PROJECT_DIR$" />
+  </component>
   <component name="ProjectRootManager" version="2" project-jdk-name="1.8" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-ideaVersion=2019.3
-lastReleaseVersion=2019.3
+ideaVersion=2020.1
+lastReleaseVersion=2020.1
 #
 pluginGroup=zd-zero
 pluginVersion=1.0.1

--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProjectComponent.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProjectComponent.java
@@ -1,10 +1,9 @@
 package zd.zero.waifu.motivator.plugin;
 
+import com.intellij.ide.AppLifecycleListener;
 import com.intellij.ide.GeneralSettings;
 import com.intellij.ide.util.PropertiesComponent;
 import com.intellij.openapi.Disposable;
-import com.intellij.openapi.application.ApplicationListener;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ProjectComponent;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
@@ -29,7 +28,7 @@ public class WaifuMotivatorProjectComponent implements ProjectComponent, Disposa
 
     private WaifuMotivatorState pluginState;
 
-    private ApplicationListener applicationListener;
+    private AppLifecycleListener applicationListener;
 
     private WaifuUnitTester unitTestListener;
 
@@ -50,16 +49,16 @@ public class WaifuMotivatorProjectComponent implements ProjectComponent, Disposa
     public void dispose() {
         this.unitTestListener.stop();
         if ( pluginState.isSayonaraEnabled() ) {
-            applicationListener.applicationExiting();
+            applicationListener.appClosing();
         }
     }
 
     private void initializeListeners() {
         unitTestListener.init();
 
-        this.applicationListener = new ApplicationListener() {
+        this.applicationListener = new AppLifecycleListener() {
             @Override
-            public void applicationExiting() {
+            public void appClosing() {
                 Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
                 if ( openProjects.length > 0 ) return;
 
@@ -68,7 +67,6 @@ public class WaifuMotivatorProjectComponent implements ProjectComponent, Disposa
                 WaifuSoundPlayerFactory.createPlayer( file ).playAndWait();
             }
         };
-        ApplicationManager.getApplication().addApplicationListener( applicationListener, this );
     }
 
     private void updatePlatformStartupConfig() {


### PR DESCRIPTION
Bumped the IJ support version to `2020.1` and resolved some deprecated APIs. For migration of plugin components to use modern APIs (#66).