### PR TITLE
feat: add settings navigation menu to plugin toolbar menu

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/actions/PluginSettingsAction.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/actions/PluginSettingsAction.java
@@ -1,0 +1,21 @@
+package zd.zero.waifu.motivator.plugin.actions;
+
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.options.ShowSettingsUtil;
+import org.jetbrains.annotations.NotNull;
+import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorSettingsPage;
+
+public class PluginSettingsAction extends AnAction {
+    @Override
+    public void actionPerformed( @NotNull AnActionEvent e ) {
+        if ( e.getProject() == null ) return;
+
+        ShowSettingsUtil.getInstance().showSettingsDialog( e.getProject(), WaifuMotivatorSettingsPage.class );
+    }
+
+    @Override
+    public void update( @NotNull AnActionEvent e ) {
+        e.getPresentation().setEnabledAndVisible( e.getProject() != null );
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,11 @@
               text="Waifu of the Day"
               description="Show me today's Waifu.">
       </action>
+      <action id="zd.zero.waifu.motivator.plugin.actions.PluginSettingsAction"
+              class="zd.zero.waifu.motivator.plugin.actions.PluginSettingsAction"
+              text="Settings"
+              description="Show me how to handle my Waifu.">
+      </action>
 
       <add-to-group group-id="MainMenu" relative-to-action="HelpMenu" anchor="before"/>
     </group>


### PR DESCRIPTION
This PR added a new menu to the plugin toolbar menu to easily navigate to the plugin settings.

<img width="133" alt="settings menu" src="https://user-images.githubusercontent.com/21978370/79053529-b6023200-7c70-11ea-9207-8e78f62c7124.png">

This will open up the "Waifu Motivator" settings page.


Resolves #69 