### PR TITLE
bug: properly style waifu of the day based on theme

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/dialog/WaifuOfTheDayDialog.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/dialog/WaifuOfTheDayDialog.java
@@ -14,6 +14,7 @@ import com.intellij.util.ResourceUtil;
 import com.intellij.util.text.DateFormatUtil;
 import com.intellij.util.ui.JBDimension;
 import com.intellij.util.ui.JBUI;
+import com.intellij.util.ui.StartupUiUtil;
 import org.apache.commons.lang.StringUtils;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -46,8 +47,6 @@ public class WaifuOfTheDayDialog extends DialogWrapper {
     private static final String WAIFU_OF_THE_DAY_IMAGE_PATH = WAIFU_OF_THE_DAY_BASE_PATH + "images/";
 
     private static final String WAIFU_OF_THE_DAY_TEMPLATE = "WaifuOfTheDayTemplate.html";
-
-    private static final String WAIFU_OF_THE_DAY_STYLE = "style.css";
 
     private static final String WAIFU_OF_THE_DAY_CONTENT = "waifu.json";
 
@@ -229,7 +228,8 @@ public class WaifuOfTheDayDialog extends DialogWrapper {
 
 
     private String getCssContent() throws IOException {
-        return getContent( WAIFU_OF_THE_DAY_STYLE );
+        String style = StartupUiUtil.isUnderDarcula() ? "darcula_style.css" : "style.css";
+        return getContent( style );
     }
 
     @Nullable

--- a/src/main/resources/waifu_of_the_day/darcula_style.css
+++ b/src/main/resources/waifu_of_the_day/darcula_style.css
@@ -1,0 +1,42 @@
+body {
+    font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+    color: #bbbbbb;
+}
+
+h1, h2, h3,
+h4, h5, h6,
+p, a {
+    margin: 8px 0 0;
+    padding: 0;
+}
+
+a {
+    display: inline-block;
+    margin-top: 50px;
+    text-decoration: none;
+}
+
+a,
+a:link,
+a:visited,
+a:hover,
+a:active {
+    color: #1565C0;
+}
+
+.waifu-image {
+    text-align: center;
+}
+
+.waifu-image img {
+    display: inline-block;
+    width: 100px;
+}
+
+.title, .subtitle {
+    text-align: center;
+}
+
+.subtitle {
+    margin: 4px 0 8px;
+}


### PR DESCRIPTION
This PR added a different styling if the theme is dark to improve the readability on Waifu of the Day.

Resolves #73 