### PR TITLE
bug: assertion error in plugin state

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorPluginState.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorPluginState.java
@@ -32,7 +32,7 @@ public class WaifuMotivatorPluginState implements PersistentStateComponent<Waifu
 
     @Override
     public void loadState( @NotNull WaifuMotivatorState state ) {
-        XmlSerializerUtil.copyBean( state, this );
+        XmlSerializerUtil.copyBean( state, this.state );
     }
 
 }


### PR DESCRIPTION
This PR updated the state which instead of the object `WaifuMotivatorState` is used, the  `WaifuMotivatorPluginState` was used.

Resolves #83 