### PR TITLE
fix: IllegalStateException when sound is disabled

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
@@ -70,8 +70,8 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
 
     private void initializeStartupMotivator() {
         AlertConfiguration config = AlertConfiguration.builder()
-                .isAlertEnabled( pluginState.isStartupMotivationEnabled() )
-                .isDisplayNotificationEnabled( true )
+                .isAlertEnabled( pluginState.isStartupMotivationEnabled() || pluginState.isStartupMotivationSoundEnabled())
+                .isDisplayNotificationEnabled( pluginState.isStartupMotivationEnabled() )
                 .isSoundAlertEnabled( pluginState.isStartupMotivationSoundEnabled() )
                 .build();
         WaifuMotivatorAlert motivatorAlert = WaifuMotivatorAlertFactory.createAlert(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/WaifuMotivatorAlertImpl.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/WaifuMotivatorAlertImpl.java
@@ -36,7 +36,7 @@ public class WaifuMotivatorAlertImpl implements WaifuMotivatorAlert {
     public void onAlertClosed( Notification notification ) {
         long duration = System.currentTimeMillis() - notification.getTimestamp();
         boolean isExpired = ( duration / 1000 ) >= 10;
-        if ( !isExpired ) {
+        if ( !isExpired && config.isSoundAlertEnabled() ) {
             player.stop();
         }
     }


### PR DESCRIPTION
The reason why `IllegalStateException` is thrown is it tries to stop the player even though it is not started because it was disabled at the first place, the solution was to check if the sound is enabled.

Resolves #95