### PR TITLE
chore: settings tooltip descriptions

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
@@ -32,6 +32,7 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/MessageBundle" key="settings.enable.startup.motivation"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.startup.motivation.tooltip"/>
         </properties>
       </component>
       <component id="b8976" class="javax.swing.JCheckBox" binding="enableUnitTesterMotivation">
@@ -41,6 +42,7 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/MessageBundle" key="settings.enable.unit.tester.motivation"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.unit.tester.motivation.tooltip"/>
         </properties>
       </component>
       <component id="196ab" class="javax.swing.JCheckBox" binding="enableWaifuOfTheDay">
@@ -50,6 +52,7 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/MessageBundle" key="settings.enable.waifu.of.the.day.and.replace.tip.of.the.day"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.waifu.of.the.day.and.replace.tip.of.the.day.tooltip"/>
         </properties>
       </component>
       <component id="d2932" class="javax.swing.JCheckBox" binding="enableMotivateMeSound">
@@ -58,7 +61,8 @@
           <forms/>
         </constraints>
         <properties>
-          <text resource-bundle="messages/MessageBundle" key="settings.enable.sound.on.motivateme"/>
+          <text resource-bundle="messages/MessageBundle" key="settings.enable.sound.on.motivate.me"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.sound.on.motivate.me.tooltip"/>
         </properties>
       </component>
       <component id="46af5" class="javax.swing.JLabel">
@@ -86,6 +90,7 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/MessageBundle" key="settings.enable.startup.motivation.sound"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.startup.motivation.sound.tooltip"/>
         </properties>
       </component>
       <component id="6f2eb" class="javax.swing.JCheckBox" binding="enableUnitTesterMotivationSound">
@@ -95,6 +100,7 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/MessageBundle" key="settings.enable.unit.tester.motivation.sound"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.unit.tester.motivation.sound.tooltip"/>
         </properties>
       </component>
       <component id="77db" class="javax.swing.JCheckBox" binding="enableSayonara">
@@ -104,6 +110,7 @@
         </constraints>
         <properties>
           <text resource-bundle="messages/MessageBundle" key="settings.enable.sayonara.play.sound.on.project.exit"/>
+          <toolTipText resource-bundle="messages/MessageBundle" key="settings.enable.sayonara.play.sound.on.project.exit.tooltip"/>
         </properties>
       </component>
     </children>

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -1,11 +1,20 @@
 title.tip.waifu.of.the.day=Waifu of the Day
 action.view.anime=View &Anime
+
+# Settings
 settings.actions=Actions
-settings.enable.startup.motivation=Enable &Startup Motivation
-settings.enable.unit.tester.motivation=Enable Unit &Tester Motivation
-settings.enable.waifu.of.the.day.and.replace.tip.of.the.day=Enable Waifu of the &Day and replace Tip of the Day
 settings.sounds=Sounds
+settings.enable.startup.motivation=Enable &Startup Motivation
+settings.enable.startup.motivation.tooltip=Displays the motivation notification on startup immediately after the indexing finished.
+settings.enable.unit.tester.motivation=Enable Unit &Tester Motivation
+settings.enable.unit.tester.motivation.tooltip=A notification is triggered whenever a unit test passes or fails.
+settings.enable.waifu.of.the.day.and.replace.tip.of.the.day=Enable Waifu of the &Day and replace Tip of the Day
+settings.enable.waifu.of.the.day.and.replace.tip.of.the.day.tooltip=Replaces the out-of-the-box Tip of the Day and replaces with a Waifu of the Day where it displays random Waifu with their respective information.
 settings.enable.startup.motivation.sound=Enable Startup &Motivation Sound
+settings.enable.startup.motivation.sound.tooltip=Plays a motivation sound on startup immediately after the indexing finished.
 settings.enable.unit.tester.motivation.sound=Enable U&nit Tester Motivation Sound
-settings.enable.sound.on.motivateme=&Enable sound on Motivate Me
-settings.enable.sayonara.play.sound.on.project.exit=Enable Sayonara (play sound on project e&xit)
+settings.enable.unit.tester.motivation.sound.tooltip=A sound motivation is triggered whenever a unit test passes or fails.
+settings.enable.sound.on.motivate.me=&Enable sound on Motivate Me
+settings.enable.sound.on.motivate.me.tooltip=Plays a sound whenever 'Motivate Me' action is invoked.
+settings.enable.sayonara.play.sound.on.project.exit=Enable Sayonara
+settings.enable.sayonara.play.sound.on.project.exit.tooltip=Plays a sound on the last project exit.


### PR DESCRIPTION
Updated the message bundle to include settings tooltips to add more information to what the setting does.

### Waifu of the Day tooltip
<img width="992" alt="Screen Shot 2020-05-11 at 4 19 54 AM" src="https://user-images.githubusercontent.com/21978370/81509760-9cbbd680-933f-11ea-963d-28fd21ab175c.png">

<img width="1007" alt="Screen Shot 2020-05-11 at 4 23 52 AM" src="https://user-images.githubusercontent.com/21978370/81509782-ad6c4c80-933f-11ea-91d2-b1d7d48af197.png">


Resolves #94 