### PR TITLE
fix: waifu unit tester executes multiple times

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_size = 4
 trim_trailing_whitespace=true
 insert_final_newline = true
 end_of_line=lf
+
+[*.xml]
+indent_size = 2

--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
@@ -32,10 +32,12 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
     private WaifuUnitTester unitTestListener;
 
     @Override
-    public void projectOpened( @NotNull Project project ) {
-        this.project = project;
+    public void projectOpened( @NotNull Project projectOpened ) {
+        if ( this.project != null ) return;
+
+        this.project = projectOpened;
         this.pluginState = WaifuMotivatorPluginState.getPluginState();
-        this.unitTestListener = WaifuUnitTester.newInstance( project );
+        this.unitTestListener = WaifuUnitTester.newInstance( projectOpened );
 
         updatePlatformStartupConfig();
         initializeListeners();
@@ -63,7 +65,7 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
 
     private void updatePlatformStartupConfig() {
         boolean isInitialPlatformTipUpdated = Boolean.parseBoolean( PropertiesComponent.getInstance()
-                .getValue( IS_INITIAL_PLATFORM_TIP_UPDATED, "" ) );
+            .getValue( IS_INITIAL_PLATFORM_TIP_UPDATED, "" ) );
         if ( !isInitialPlatformTipUpdated ) {
             PropertiesComponent.getInstance().setValue( IS_INITIAL_PLATFORM_TIP_UPDATED, true );
             GeneralSettings.getInstance().setShowTipsOnStartup( !pluginState.isWaifuOfTheDayEnabled() );
@@ -72,12 +74,12 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
 
     private void initializeStartupMotivator() {
         AlertConfiguration config = AlertConfiguration.builder()
-                .isAlertEnabled( pluginState.isStartupMotivationEnabled() || pluginState.isStartupMotivationSoundEnabled())
-                .isDisplayNotificationEnabled( pluginState.isStartupMotivationEnabled() )
-                .isSoundAlertEnabled( pluginState.isStartupMotivationSoundEnabled() )
-                .build();
+            .isAlertEnabled( pluginState.isStartupMotivationEnabled() || pluginState.isStartupMotivationSoundEnabled() )
+            .isDisplayNotificationEnabled( pluginState.isStartupMotivationEnabled() )
+            .isSoundAlertEnabled( pluginState.isStartupMotivationSoundEnabled() )
+            .build();
         WaifuMotivatorAlert motivatorAlert = WaifuMotivatorAlertFactory.createAlert(
-                project, AlertAssetProvider.getRandomAssetByCategory( WaifuMotivatorAlertAssetCategory.NEUTRAL ), config );
+            project, AlertAssetProvider.getRandomAssetByCategory( WaifuMotivatorAlertAssetCategory.NEUTRAL ), config );
 
         if ( !project.isInitialized() ) {
             StartupManager.getInstance( project ).registerPostStartupActivity( motivatorAlert::alert );

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -9,15 +9,15 @@
 
   <depends>com.intellij.modules.platform</depends>
 
-   <!--    Leave this in here so the IDE gives you feedback on-->
-   <!--    What APIs are available-->
-   <idea-version since-build="201.3803.71"/>
+  <!--    Leave this in here so the IDE gives you feedback on-->
+  <!--    What APIs are available-->
+  <idea-version since-build="201.3803.71"/>
 
-    <extensions defaultExtensionNs="com.intellij">
+  <extensions defaultExtensionNs="com.intellij">
     <applicationService
-        serviceImplementation="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState"/>
+      serviceImplementation="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState"/>
     <applicationConfigurable
-        instance="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorSettingsPage"/>
+      instance="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorSettingsPage"/>
     <postStartupActivity id="WaifuOfTheDayStartupActivity"
                          implementation="zd.zero.waifu.motivator.plugin.WaifuOfTheDayStartupActivity"/>
   </extensions>


### PR DESCRIPTION
Resolves #110 

This PR added a condition to add listeners only if the project is not opened beforehand to avoid multiple listeners attached to the project.