### PR TITLE
fix:  enable re-hydration of local asset checks on startup

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalAssetService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalAssetService.kt
@@ -21,8 +21,8 @@ private enum class AssetChangedStatus {
 
 object LocalAssetService {
     private val log = Logger.getInstance(this::class.java)
-    private val assetChecks: MutableMap<String, Instant> = readPreviousAssetChecks()
     private val gson = GsonBuilder().setPrettyPrinting().create()
+    private val assetChecks: MutableMap<String, Instant> = readPreviousAssetChecks()
 
     fun hasAssetChanged(
         localInstallPath: Path,


### PR DESCRIPTION
I wrote code attempting to read the asset-checks json before initializing the tool that reads json.

:facepalm: 

