### PR TITLE
fix: visual motivation alert style

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/VisualWaifuNotification.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/VisualWaifuNotification.kt
@@ -4,6 +4,7 @@ import com.intellij.notification.Notification
 import com.intellij.notification.impl.NotificationsManagerImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.Balloon
+import com.intellij.openapi.util.Ref
 import com.intellij.ui.BalloonLayoutData
 import zd.zero.waifu.motivator.plugin.assets.MotivationAsset
 import zd.zero.waifu.motivator.plugin.onboarding.BalloonTools.fetchBalloonParameters
@@ -23,7 +24,7 @@ class VisualWaifuNotification(
                 updateNotification,
                 true,
                 true,
-                BalloonLayoutData.fullContent(),
+                createLayoutDataRef(),
                 ApplicationService.instance
             )
             balloon.setAnimationEnabled(true)
@@ -33,5 +34,13 @@ class VisualWaifuNotification(
         }
 
         return updateNotification
+    }
+
+    private fun createLayoutDataRef(): Ref<BalloonLayoutData> {
+        val balloonLayoutData = BalloonLayoutData.createEmpty()
+        balloonLayoutData.showFullContent = true
+        balloonLayoutData.showMinSize = false
+        balloonLayoutData.welcomeScreen = true
+        return Ref(balloonLayoutData)
     }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetModels.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetModels.kt
@@ -3,9 +3,16 @@ package zd.zero.waifu.motivator.plugin.assets
 interface AssetDefinition {
     val categories: Array<WaifuAssetCategory>
 }
+
+data class ImageDimension(
+    val width: Int,
+    val height: Int
+)
+
 data class VisualMotivationAssetDefinition(
     val imagePath: String,
     val imageAlt: String,
+    val imageDimensions: ImageDimension,
     override val categories: Array<WaifuAssetCategory>
 ) : AssetDefinition
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualAssetManager.kt
@@ -56,6 +56,7 @@ object VisualAssetManager {
         VisualMotivationAssetDefinition(
             "caramelldansen.gif",
             "Caramelldansen",
+            ImageDimension(320, 240),
             arrayOf(
                 WaifuAssetCategory.CELEBRATION
             )
@@ -63,6 +64,7 @@ object VisualAssetManager {
         VisualMotivationAssetDefinition(
             "kill-la-kill-caramelldansen.gif",
             "Caramelldansen",
+            ImageDimension(250, 184),
             arrayOf(
                 WaifuAssetCategory.CELEBRATION
             )

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -65,7 +65,7 @@ object VisualMotivationAssetProvider {
         )
 
     private fun getExtraStyles(imageDimensions: ImageDimension): String =
-        if (SystemInfo.isLinux) {
+        if (!SystemInfo.isMac) {
             "width: ${reduceSize(imageDimensions.width, 0.75)}px;" +
                 "height: ${reduceSize(imageDimensions.height, 0.85)}px"
         } else {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -1,6 +1,7 @@
 package zd.zero.waifu.motivator.plugin.assets
 
 import kotlin.random.Random
+import com.intellij.openapi.util.SystemInfo
 
 enum class WaifuAssetCategory {
     CELEBRATION,
@@ -55,11 +56,22 @@ object VisualMotivationAssetProvider {
         MotivationAsset(
             "&nbsp;&nbsp;&nbsp;${textualAssetDefinition.title}",
             """
-                <div style="margin: 5px 5px 5px 10px">
+                <div style="margin: 5px 5px 5px 10px;${getExtraStyles(visualAssetDefinition.imageDimensions)}" >
                     <img src='${visualAssetDefinition.imagePath}' alt='${visualAssetDefinition.imageAlt}'/>
                 </div>
             """.trimIndent(),
             audibleAssetDefinition.soundFile,
             arrayOf()
         )
+
+    private fun getExtraStyles(imageDimensions: ImageDimension): String =
+        if (SystemInfo.isLinux) {
+            "width: ${reduceSize(imageDimensions.width, 0.75)}px;" +
+                "height: ${reduceSize(imageDimensions.height, 0.85)}px"
+        } else {
+            ""
+        }
+
+    private fun reduceSize(dimensionToReduce: Int, modifier: Double) =
+        (dimensionToReduce.toDouble() * modifier).toInt()
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -55,8 +55,8 @@ object VisualMotivationAssetProvider {
         MotivationAsset(
             textualAssetDefinition.title,
             """
-                 <img src='${visualAssetDefinition.imagePath}' alt='${visualAssetDefinition.imageAlt}' width='256' />
-                 <br><br><br><br><br><br><br><br><br><br>
+                 <img src='${visualAssetDefinition.imagePath}' alt='${visualAssetDefinition.imageAlt}' width='96px' />
+                 <br>
                  <p>${textualAssetDefinition.message}</p>
                 """.trimIndent(),
             audibleAssetDefinition.soundFile,

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -53,12 +53,12 @@ object VisualMotivationAssetProvider {
         audibleAssetDefinition: AudibleMotivationAssetDefinition
     ): MotivationAsset =
         MotivationAsset(
-            textualAssetDefinition.title,
+            "&nbsp;&nbsp;&nbsp;${textualAssetDefinition.title}",
             """
-                 <img src='${visualAssetDefinition.imagePath}' alt='${visualAssetDefinition.imageAlt}' width='96px' />
-                 <br>
-                 <p>${textualAssetDefinition.message}</p>
-                """.trimIndent(),
+                <div style="margin: 5px 5px 5px 10px">
+                    <img src='${visualAssetDefinition.imagePath}' alt='${visualAssetDefinition.imageAlt}'/>
+                </div>
+            """.trimIndent(),
             audibleAssetDefinition.soundFile,
             arrayOf()
         )

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -1,7 +1,6 @@
 package zd.zero.waifu.motivator.plugin.assets
 
 import kotlin.random.Random
-import com.intellij.openapi.util.SystemInfo
 
 enum class WaifuAssetCategory {
     CELEBRATION,
@@ -65,12 +64,8 @@ object VisualMotivationAssetProvider {
         )
 
     private fun getExtraStyles(imageDimensions: ImageDimension): String =
-        if (!SystemInfo.isMac) {
-            "width: ${reduceSize(imageDimensions.width, 0.75)}px;" +
-                "height: ${reduceSize(imageDimensions.height, 0.85)}px"
-        } else {
-            ""
-        }
+        "width: ${reduceSize(imageDimensions.width, 0.75)}px;" +
+            "height: ${reduceSize(imageDimensions.height, 0.85)}px"
 
     private fun reduceSize(dimensionToReduce: Int, modifier: Double) =
         (dimensionToReduce.toDouble() * modifier).toInt()


### PR DESCRIPTION
Resolves #140 

Updated the balloon alert style.

<img width="498" alt="Screen Shot 2020-08-05 at 21 21 07" src="https://user-images.githubusercontent.com/21978370/89417690-992ec480-d761-11ea-9cd4-e300863e551d.png">

<img width="302" alt="Screen Shot 2020-08-05 at 21 21 01" src="https://user-images.githubusercontent.com/21978370/89417700-9d5ae200-d761-11ea-8390-5e942281a4bf.png">


A bit of a hack but we can now avoid displaying a scrollbar, changed the layout data to enable `welcomeScreen` flag.

This will then make the ballon to use text content instead of adding a pane.

https://github.com/JetBrains/intellij-community/blob/b59fbaba724d5c7e016431383a4b28963cba4ae8/platform/platform-impl/src/com/intellij/notification/impl/NotificationsManagerImpl.java#L570-L572

The consequence is not showing the balloon icon on the left side, but I think that this is a lesser consequence for avoiding scrollbars.

<img width="330" alt="89402814-ffa7e880-d749-11ea-91cb-dfce12d2ba6c" src="https://user-images.githubusercontent.com/21978370/89417589-73092480-d761-11ea-98c4-af6001793b22.png">


https://github.com/JetBrains/intellij-community/blob/b59fbaba724d5c7e016431383a4b28963cba4ae8/platform/platform-impl/src/com/intellij/notification/impl/NotificationsManagerImpl.java#L574-L588

Now that we don't have the icon on the left side of the balloon, now made a no breaking space to the title, for the normal white space is trimmed.


As you would notice that the text under the image has fewer space, before it was:

<img width="322" alt="Screen Shot 2020-08-05 at 17 57 10" src="https://user-images.githubusercontent.com/21978370/89402878-15b5a900-d74a-11ea-81c1-e752b635a3ce.png">

Is there a reason why it has that much space?
For sometimes I get a scrollbar for the alert.
![scroll](https://user-images.githubusercontent.com/21978370/89403593-231f6300-d74b-11ea-907a-685a81858f9d.gif)

