### PR TITLE
fix: redundant title description

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,4 @@
-# Waifu Motivator plugin
-## Changelog
+# Changelog
 
 ## [v1.1.2](https://github.com/zd-zero/waifu-motivator-plugin/releases/tag/v1.1.2)
 #### 24/04/20


### PR DESCRIPTION
I hate myself for this, we have a redundant plugin title because `CHANGELOG.md` file contains the title.
<img width="494" alt="Screen Shot 2020-08-11 at 21 56 23" src="https://user-images.githubusercontent.com/21978370/89906469-04730d80-dc1e-11ea-8924-a8dc4ef9bd93.png">
