### PR TITLE
fix: Ignored tests with no failures is success

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ intellij {
     type System.getenv().getOrDefault("INTELLIJ_TYPE", "IC")
     println "Building for IntelliJ version: ${version}"
 
+    alternativeIdePath idePath
 }
 
 compileKotlin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,5 +5,7 @@ untilBuildVersion=202.*
 pluginGroup=zd-zero
 pluginVersion=1.2
 
+# This property allows you
+# to run/develop the plugin on a different IDE
+# ex: idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/202.6250.10
 idePath=
-#idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\WebStorm\\ch-0\\202.6397.88

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,3 +4,6 @@ untilBuildVersion=202.*
 #
 pluginGroup=zd-zero
 pluginVersion=1.2
+
+idePath=
+#idePath=C:\\Users\\birdm.DESKTOP-FO92PV5\\AppData\\Local\\JetBrains\\Toolbox\\apps\\WebStorm\\ch-0\\202.6397.88

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ pluginVersion=1.2
 
 # This property allows you
 # to run/develop the plugin on a different IDE
-# ex: idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/202.6250.10
+# e.g.: idePath=/home/alex/.local/share/JetBrains/Toolbox/apps/WebStorm/ch-0/202.6250.10
 idePath=

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/WaifuUnitTesterImpl.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/WaifuUnitTesterImpl.java
@@ -3,6 +3,7 @@ package zd.zero.waifu.motivator.plugin.listeners;
 import com.intellij.execution.testframework.sm.runner.SMTRunnerEventsAdapter;
 import com.intellij.execution.testframework.sm.runner.SMTRunnerEventsListener;
 import com.intellij.execution.testframework.sm.runner.SMTestProxy;
+import com.intellij.execution.testframework.sm.runner.states.TestStateInfo;
 import com.intellij.openapi.externalSystem.service.execution.ExternalSystemProcessHandler;
 import com.intellij.util.messages.MessageBusConnection;
 import org.jetbrains.annotations.NotNull;
@@ -27,7 +28,7 @@ public class WaifuUnitTesterImpl implements WaifuUnitTester {
             public void onTestingFinished( @NotNull SMTestProxy.SMRootTestProxy testsRoot ) {
                 if ( testsRoot.wasTerminated() || testsRoot.isInterrupted()
                     || isCancelledOnExternalProcess( testsRoot ) ) return;
-                if ( testsRoot.isPassed() ) {
+                if ( testsRoot.isPassed() || isSuccessWithIgnoredTests(testsRoot) ) {
                     listener.onUnitTestPassed();
                 } else {
                     listener.onUnitTestFailed();
@@ -39,6 +40,10 @@ public class WaifuUnitTesterImpl implements WaifuUnitTester {
     @Override
     public void stop() {
         this.busConnection.disconnect();
+    }
+
+    private boolean isSuccessWithIgnoredTests( SMTestProxy.SMRootTestProxy testsRoot ) {
+        return TestStateInfo.Magnitude.IGNORED_INDEX.equals(  testsRoot.getMagnitudeInfo() );
     }
 
     /**


### PR DESCRIPTION
# Motivation

Fixes #153 

## Notes

This wasn't just a WebStorm/Jest issue, if a any JUnit test was annotated with `@Ignore` would also cause this bug.