### PR TITLE
chore: bump pre-merge pipeline JRE to 11

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: Set up JDK 1.8
+    - name: Set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 11
     - name: Build with Gradle
       run: ./gradlew build
 


### PR DESCRIPTION
# Motivation

I am writing a bunch of tests for #159 and I require a JRE 11+ to make the happy.
Building the plugin with a JDK 11 and have it run on JDK 8 should be okay. If it doesn't, I'm not sure how my Doki-Theme plugin works then :)

