### PR TITLE
chore: address checked exception error reporting

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/dialog/WaifuOfTheDayDialog.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/dialog/WaifuOfTheDayDialog.java
@@ -163,7 +163,7 @@ public class WaifuOfTheDayDialog extends DialogWrapper {
             this.browser.setText( getUpdatedTemplateContent() );
             this.browser.setCaretPosition( 0 ); // resets scroll back to top
         } catch ( IOException e ) {
-            LOGGER.error( e.getMessage(), e );
+            LOGGER.warn( e.getMessage(), e );
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalStorageService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalStorageService.kt
@@ -15,7 +15,7 @@ object LocalStorageService {
         try {
             Files.createDirectories(directoriesToCreate.parent)
         } catch (e: IOException) {
-            log.error("Unable to create directories $directoriesToCreate for raisins", e)
+            log.warn("Unable to create directories $directoriesToCreate for raisins", e)
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalStorageService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalStorageService.kt
@@ -15,7 +15,7 @@ object LocalStorageService {
         try {
             Files.createDirectories(directoriesToCreate.parent)
         } catch (e: IOException) {
-            log.warn("Unable to create directories $directoriesToCreate for raisins", e)
+            log.error("Unable to create directories $directoriesToCreate", e)
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/player/DefaultWaifuSoundPlayer.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/player/DefaultWaifuSoundPlayer.java
@@ -33,7 +33,7 @@ public final class DefaultWaifuSoundPlayer implements WaifuSoundPlayer {
             clip = SoundClipUtil.openClip( soundStream );
             clip.start();
         } catch ( IOException | LineUnavailableException | UnsupportedAudioFileException e ) {
-            LOGGER.error( e.getMessage(), e );
+            LOGGER.warn( e.getMessage(), e );
         }
     }
 
@@ -42,7 +42,7 @@ public final class DefaultWaifuSoundPlayer implements WaifuSoundPlayer {
         try {
             Thread.sleep( clip.getMicrosecondLength() / 1000 );
         } catch ( InterruptedException e ) {
-            LOGGER.error( e.getMessage(), e );
+            LOGGER.warn( e.getMessage(), e );
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/player/Mp3WaifuSoundPlayer.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/player/Mp3WaifuSoundPlayer.java
@@ -58,7 +58,7 @@ public final class Mp3WaifuSoundPlayer implements WaifuSoundPlayer {
             InputStream soundStream = new BufferedInputStream( Files.newInputStream( soundFilePath ));
             playSound( runnableConsumer, soundStream );
         } catch ( IOException e ) {
-            LOGGER.error( e.getMessage(), e );
+            LOGGER.warn( e.getMessage(), e );
         }
     }
 
@@ -69,7 +69,7 @@ public final class Mp3WaifuSoundPlayer implements WaifuSoundPlayer {
             player.setPlayBackListener( buildPlaybackListener( soundStream ) );
             runnableConsumer.accept( this::invokePlay );
         } catch ( Exception e ) {
-            LOGGER.error( e.getMessage(), e );
+            LOGGER.warn( e.getMessage(), e );
             soundStream.close();
         }
     }
@@ -82,7 +82,7 @@ public final class Mp3WaifuSoundPlayer implements WaifuSoundPlayer {
                 try {
                     soundStream.close();
                 } catch ( IOException e ) {
-                    e.printStackTrace();
+                    LOGGER.warn( "Unable to close sound stream", e );
                 }
             }
         };
@@ -92,7 +92,7 @@ public final class Mp3WaifuSoundPlayer implements WaifuSoundPlayer {
         try {
             player.play();
         } catch ( JavaLayerException e ) {
-            LOGGER.error( "Cannot play sound '" + soundFilePath + "': " + e.getMessage(), e );
+            LOGGER.warn( "Cannot play sound '" + soundFilePath + "': " + e.getMessage(), e );
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/player/WaifuSoundPlayerFactory.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/player/WaifuSoundPlayerFactory.java
@@ -19,18 +19,20 @@ public final class WaifuSoundPlayerFactory {
             .filter( f -> f.contains( "." ) )
             .map( f -> f.substring( f.lastIndexOf( '.' ) + 1 ) ).orElse( "" );
 
-        Optional<SupportedFile> supportedFile = SupportedFile.ofExtension( extension );
-        if ( supportedFile.isPresent() ) {
-            switch ( supportedFile.get() ) {
-                case CLIP:
-                    return DefaultWaifuSoundPlayer.ofFile( fileName );
+        return SupportedFile.ofExtension( extension )
+            .map( fileType -> {
+                switch ( fileType ) {
+                    case CLIP:
+                        return DefaultWaifuSoundPlayer.ofFile( fileName );
 
-                case MP3:
-                    return Mp3WaifuSoundPlayer.ofFile( fileName );
-            }
-        }
+                    case MP3:
+                        return Mp3WaifuSoundPlayer.ofFile( fileName );
 
-        return EmptyWaifuSoundPlayer.of( fileName );
+                    default:
+                        return EmptyWaifuSoundPlayer.of( fileName );
+                }
+            } )
+            .orElse( EmptyWaifuSoundPlayer.of( fileName ) );
     }
 
     private enum SupportedFile {


### PR DESCRIPTION
# Motivation

Closes #167 

So when we log things as `error` that gives the user the option to report the error. 
I would prefer that any error that the user reports come from something unexpected and actionable (ie un-caught runtime exceptions). Reporting a checked exception (one that we know will happen) that we just log is not very useful, in my opinion. We knew it was going to happen and we just wanted to log it. If we keep it at `warn` it will still show in the log. That way the user can manually report the issue if it is severe enough. Plus this issue has only been reported once, so it is not a wide spread issue.

I only left ~~one~~ two error logs, because that error prevents the plugin from ever initializing. 

