### PR TITLE
chore: back to using filename utils

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/player/WaifuSoundPlayerFactory.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/player/WaifuSoundPlayerFactory.java
@@ -1,5 +1,6 @@
 package zd.zero.waifu.motivator.plugin.player;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import java.nio.file.Path;
@@ -13,11 +14,7 @@ public final class WaifuSoundPlayerFactory {
     }
 
     public static WaifuSoundPlayer createPlayer( Path fileName ) {
-        String extension = Optional.ofNullable( fileName )
-            .map( Path::getFileName )
-            .map( String::valueOf )
-            .filter( f -> f.contains( "." ) )
-            .map( f -> f.substring( f.lastIndexOf( '.' ) + 1 ) ).orElse( "" );
+        String extension = FilenameUtils.getExtension( fileName.getFileName().toString() );
 
         Optional<SupportedFile> supportedFile = SupportedFile.ofExtension( extension );
         if ( supportedFile.isPresent() ) {


### PR DESCRIPTION
# Motivation

Closes #172 

I tested this on both IntelliJ and WebStorm. It works with it. If I removed the `implementation 'commons-io:commons-io:2.6'` line from the build gradle, it would stop working in WebStorm, so it is safe to say this works as expected. 