### PR TITLE
fix: allow customization of allowed exit codes.

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
@@ -20,14 +20,18 @@ import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorState.Companion.DEF
 const val OK_EXIT_CODE = 0
 const val FORCE_KILLED_EXIT_CODE = 130
 
+fun String.toExitCodes() : Set<Int> = this.split(DEFAULT_DELIMITER).map { it.trim().toInt() }.toSet()
+
 class ExitCodeListener(private val project: Project) : Runnable, Disposable {
     private val messageBus = ApplicationManager.getApplication().messageBus.connect()
 
-    private var allowedExitCodes = extractExitCodes(WaifuMotivatorPluginState.getPluginState())
+    private var allowedExitCodes = WaifuMotivatorPluginState.getPluginState()
+        .allowedExitCodes.toExitCodes()
     init {
         messageBus.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object: PluginSettingsListener {
             override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
-                allowedExitCodes = extractExitCodes(newPluginState)
+                allowedExitCodes = newPluginState
+                    .allowedExitCodes.toExitCodes()
             }
         })
 
@@ -44,10 +48,6 @@ class ExitCodeListener(private val project: Project) : Runnable, Disposable {
             }
         })
     }
-
-    private fun extractExitCodes(newPluginState1: WaifuMotivatorState) =
-        newPluginState1
-            .allowedExitCodes.split(DEFAULT_DELIMITER).map { it.trim().toInt() }.toSet()
 
     override fun dispose() {
         messageBus.dispose()

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
@@ -20,7 +20,9 @@ import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorState.Companion.DEF
 const val OK_EXIT_CODE = 0
 const val FORCE_KILLED_EXIT_CODE = 130
 
-fun String.toExitCodes(): Set<Int> = this.split(DEFAULT_DELIMITER).map { it.trim().toInt() }.toSet()
+fun String.toExitCodes(): Set<Int> = this.split(DEFAULT_DELIMITER)
+    .filter { it.isNotEmpty() }
+    .map { it.trim().toInt() }.toSet()
 
 class ExitCodeListener(private val project: Project) : Runnable, Disposable {
     private val messageBus = ApplicationManager.getApplication().messageBus.connect()

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
@@ -20,7 +20,7 @@ import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorState.Companion.DEF
 const val OK_EXIT_CODE = 0
 const val FORCE_KILLED_EXIT_CODE = 130
 
-fun String.toExitCodes() : Set<Int> = this.split(DEFAULT_DELIMITER).map { it.trim().toInt() }.toSet()
+fun String.toExitCodes(): Set<Int> = this.split(DEFAULT_DELIMITER).map { it.trim().toInt() }.toSet()
 
 class ExitCodeListener(private val project: Project) : Runnable, Disposable {
     private val messageBus = ApplicationManager.getApplication().messageBus.connect()
@@ -28,7 +28,7 @@ class ExitCodeListener(private val project: Project) : Runnable, Disposable {
     private var allowedExitCodes = WaifuMotivatorPluginState.getPluginState()
         .allowedExitCodes.toExitCodes()
     init {
-        messageBus.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object: PluginSettingsListener {
+        messageBus.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object : PluginSettingsListener {
             override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
                 allowedExitCodes = newPluginState
                     .allowedExitCodes.toExitCodes()

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
@@ -247,7 +247,7 @@
               </component>
               <hspacer id="17b40">
                 <constraints>
-                  <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                  <grid row="0" column="1" row-span="2" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
               <component id="dd1d3" class="javax.swing.JCheckBox" binding="enableTaskEventSoundsCheckBox" default-binding="true">
@@ -258,15 +258,11 @@
                   <text resource-bundle="messages/MessageBundle" key="settings.task.events.sounds"/>
                 </properties>
               </component>
-              <grid id="6899b" binding="exitCodePanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
-                <margin top="0" left="0" bottom="0" right="0"/>
+              <vspacer id="15c25">
                 <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
                 </constraints>
-                <properties/>
-                <border type="none"/>
-                <children/>
-              </grid>
+              </vspacer>
             </children>
           </grid>
           <grid id="87a7f" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -320,7 +316,7 @@
               </component>
             </children>
           </grid>
-          <grid id="d1ca5" layout-manager="GridLayoutManager" row-count="3" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+          <grid id="d1ca5" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
             <margin top="0" left="0" bottom="0" right="0"/>
             <constraints>
               <tabbedpane title="Exit Code Events"/>
@@ -341,11 +337,6 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
-              <vspacer id="d3547">
-                <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </vspacer>
               <component id="34493" class="javax.swing.JCheckBox" binding="enableExitCodeSound">
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -354,6 +345,23 @@
                   <text resource-bundle="messages/MessageBundle" key="settings.exit.code.events.sound"/>
                 </properties>
               </component>
+              <component id="f2714" class="javax.swing.JLabel" binding="allowedExitCodeLabel">
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text resource-bundle="messages/MessageBundle" key="settings.exit.code.allowed"/>
+                </properties>
+              </component>
+              <grid id="c6fde" binding="exitCodePanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="3" column="0" row-span="1" col-span="2" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children/>
+              </grid>
             </children>
           </grid>
         </children>

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
@@ -250,11 +250,6 @@
                   <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                 </constraints>
               </hspacer>
-              <vspacer id="3fc1a">
-                <constraints>
-                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="6" hsize-policy="1" anchor="0" fill="2" indent="0" use-parent-layout="false"/>
-                </constraints>
-              </vspacer>
               <component id="dd1d3" class="javax.swing.JCheckBox" binding="enableTaskEventSoundsCheckBox" default-binding="true">
                 <constraints>
                   <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
@@ -263,6 +258,15 @@
                   <text resource-bundle="messages/MessageBundle" key="settings.task.events.sounds"/>
                 </properties>
               </component>
+              <grid id="6899b" binding="exitCodePanel" custom-create="true" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                <margin top="0" left="0" bottom="0" right="0"/>
+                <constraints>
+                  <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties/>
+                <border type="none"/>
+                <children/>
+              </grid>
             </children>
           </grid>
           <grid id="87a7f" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -1,7 +1,6 @@
 package zd.zero.waifu.motivator.plugin.settings;
 
 import com.intellij.ide.GeneralSettings;
-import com.intellij.ide.IdeBundle;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.SearchableConfigurable;
@@ -223,6 +222,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         }
         Arrays.stream( this.state.getAllowedExitCodes()
             .split( WaifuMotivatorState.DEFAULT_DELIMITER ) )
+            .filter( code -> !StringUtil.isEmpty( code ) )
             .map( Integer::parseInt )
             .forEach( exitCodeListModel::addRow );
         exitCodesChanged = false;

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -23,6 +23,8 @@ import zd.zero.waifu.motivator.plugin.WaifuMotivator;
 import zd.zero.waifu.motivator.plugin.service.ApplicationService;
 
 import javax.swing.*;
+import java.util.Arrays;
+import java.util.stream.IntStream;
 
 public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Configurable.NoScroll {
 
@@ -75,6 +77,8 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
     private JPanel exitCodePanel;
 
     private JLabel allowedExitCodeLabel;
+
+    private ListTableModel<Integer> exitCodeModel;
 
     public WaifuMotivatorSettingsPage() {
         this.state = WaifuMotivatorPluginState.getPluginState();
@@ -193,9 +197,16 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         this.frustrationProbabilitySlider.setValue( this.state.getProbabilityOfFrustration() );
         this.enableExitCodeNotifications.setSelected( this.state.isExitCodeNotificationEnabled() );
         this.enableExitCodeSound.setSelected( this.state.isExitCodeSoundEnabled() );
+
+        int rowCount = exitCodeModel.getRowCount();
+        if(rowCount > 0) {
+            IntStream.range( 0, rowCount + 1).forEach( exitCodeModel::removeRow );
+        }
+        Arrays.stream( this.state.getAllowedExitCodes().split( WaifuMotivatorState.DEFAULT_DELIMITER ) )
+        .map( Integer::parseInt )
+        .forEach( exitCodeModel::addRow );
     }
 
-    private ListTableModel<Integer> exitCodeModel;
     private void createUIComponents() {
         exitCodeModel = new ListTableModel<Integer>(  ) {
             @Override
@@ -204,11 +215,11 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
             }
         };
         exitCodes = new JBTable(exitCodeModel);
-        exitCodeModel.setColumnInfos(new ColumnInfo[]{new ColumnInfo<Integer, String>("") {
-            @Nullable
+        exitCodeModel.setColumnInfos(new ColumnInfo[]{new ColumnInfo<Integer, String>("Exit Code") {
+
             @Override
-            public String valueOf( Integer info) {
-                return info.toString();
+            public String valueOf( Integer integer ) {
+                return integer.toString();
             }
 
             @Override
@@ -216,15 +227,6 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
                 return true;
             }
 
-            @Override
-            public void setValue( Integer info, String value) {
-                int row = exitCodes.getSelectedRow();
-                if ( StringUtil.isEmpty(value) && row >= 0 && row < exitCodeModel.getRowCount()) {
-                    exitCodeModel.removeRow(row);
-                }
-                else {
-                }
-            }
         }});
         exitCodes.getColumnModel().setColumnMargin(0);
         exitCodes.setShowColumns(false);

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -74,6 +74,8 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
     private JPanel exitCodePanel;
 
+    private JLabel allowedExitCodeLabel;
+
     public WaifuMotivatorSettingsPage() {
         this.state = WaifuMotivatorPluginState.getPluginState();
     }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -28,7 +28,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.SpinnerNumberModel;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -84,7 +83,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
     private JLabel allowedExitCodeLabel;
 
-    private ListTableModel<String> exitCodeModel;
+    private ListTableModel<Integer> exitCodeModel;
 
     public WaifuMotivatorSettingsPage() {
         this.state = WaifuMotivatorPluginState.getPluginState();
@@ -177,8 +176,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         this.state.setExitCodeSoundEnabled( enableExitCodeSound.isSelected() );
         this.state.setAllowedExitCodes(
             IntStream.range( 0, exitCodeModel.getRowCount() )
-            .mapToObj( exitCodeModel::getRowValue )
-            .mapToInt( Integer::parseInt )
+            .map( exitCodeModel::getRowValue )
             .distinct()
             .sorted()
             .mapToObj( String::valueOf )
@@ -220,7 +218,6 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
         }
         Arrays.stream( this.state.getAllowedExitCodes().split( WaifuMotivatorState.DEFAULT_DELIMITER ) )
             .map( Integer::parseInt )
-            .map( String::valueOf )
             .forEach( exitCodeModel::addRow );
         codesChanged = false;
     }
@@ -228,38 +225,37 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
     private boolean codesChanged = false;
 
     private void createUIComponents() {
-        exitCodeModel = new ListTableModel<String>(  ) {
+        exitCodeModel = new ListTableModel<Integer>(  ) {
             @Override
             public void addRow() {
-                addRow("0");
+                addRow(0);
             }
 
         };
         exitCodeModel.addTableModelListener( e -> codesChanged = true );
 
         exitCodes = new JBTable(exitCodeModel);
-        exitCodeModel.setColumnInfos(new ColumnInfo[]{new ColumnInfo<String, String>("Exit Code") {
+        exitCodeModel.setColumnInfos(new ColumnInfo[]{new ColumnInfo<Integer, String>("Exit Code") {
 
             @Override
-            public String valueOf( String integer ) {
-                return integer;
+            public String valueOf( Integer integer ) {
+                return integer.toString();
             }
 
             @Override
-            public void setValue( String s, String value ) {
+            public void setValue( Integer s, String value ) {
                 int row = exitCodes.getSelectedRow();
-                if ( StringUtil.isEmpty(value) && row >= 0 && row < exitCodeModel.getRowCount()) {
-                    exitCodeModel.removeRow(row);
-                }
-                else {
-                    exitCodeModel.insertRow( row, value);
+                if ( StringUtil.isEmpty( value ) && row >= 0 && row < exitCodeModel.getRowCount() ) {
+                    exitCodeModel.removeRow( row );
+                } else {
+                    exitCodeModel.insertRow( row, Integer.parseInt( value ) );
                     exitCodeModel.removeRow( row + 1 );
                     exitCodes.transferFocus();
                 }
             }
 
             @Override
-            public boolean isCellEditable( String info) {
+            public boolean isCellEditable( Integer info) {
                 return true;
             }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -7,6 +7,7 @@ import com.intellij.openapi.options.Configurable;
 import com.intellij.openapi.options.SearchableConfigurable;
 import com.intellij.openapi.ui.cellvalidators.CellComponentProvider;
 import com.intellij.openapi.ui.cellvalidators.CellTooltipManager;
+import com.intellij.openapi.util.text.StringUtil;
 import com.intellij.ui.ToolbarDecorator;
 import com.intellij.ui.table.JBTable;
 import com.intellij.util.ui.ColumnInfo;
@@ -27,6 +28,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.ListSelectionModel;
 import javax.swing.SpinnerNumberModel;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -240,7 +242,20 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
             @Override
             public String valueOf( String integer ) {
-                return integer.toString();
+                return integer;
+            }
+
+            @Override
+            public void setValue( String s, String value ) {
+                int row = exitCodes.getSelectedRow();
+                if ( StringUtil.isEmpty(value) && row >= 0 && row < exitCodeModel.getRowCount()) {
+                    exitCodeModel.removeRow(row);
+                }
+                else {
+                    exitCodeModel.insertRow( row, value);
+                    exitCodeModel.removeRow( row + 1 );
+                    exitCodes.transferFocus();
+                }
             }
 
             @Override

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -200,7 +200,7 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
         int rowCount = exitCodeModel.getRowCount();
         if(rowCount > 0) {
-            IntStream.range( 0, rowCount + 1).forEach( exitCodeModel::removeRow );
+            IntStream.range( 0, rowCount).forEach( idx -> exitCodeModel.removeRow( 0 ) );
         }
         Arrays.stream( this.state.getAllowedExitCodes().split( WaifuMotivatorState.DEFAULT_DELIMITER ) )
         .map( Integer::parseInt )

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
@@ -1,7 +1,11 @@
 package zd.zero.waifu.motivator.plugin.settings
 
+import zd.zero.waifu.motivator.plugin.listeners.FORCE_KILLED_EXIT_CODE
+import zd.zero.waifu.motivator.plugin.listeners.OK_EXIT_CODE
+
 class WaifuMotivatorState {
     companion object {
+        const val DEFAULT_DELIMITER = "/"
         const val DEFAULT_IDLE_TIMEOUT_IN_MINUTES: Long = 5L
         const val DEFAULT_EVENTS_BEFORE_FRUSTRATION: Int = 5
         const val DEFAULT_FRUSTRATION_PROBABILITY: Int = 75
@@ -44,6 +48,11 @@ class WaifuMotivatorState {
     var eventsBeforeFrustration = DEFAULT_EVENTS_BEFORE_FRUSTRATION
 
     var probabilityOfFrustration = DEFAULT_FRUSTRATION_PROBABILITY
+
+    var allowedExitCodes = listOf(
+        OK_EXIT_CODE,
+        FORCE_KILLED_EXIT_CODE
+    ).joinToString(DEFAULT_DELIMITER)
 
     var version = "v0.0.0"
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
@@ -5,7 +5,7 @@ import zd.zero.waifu.motivator.plugin.listeners.OK_EXIT_CODE
 
 class WaifuMotivatorState {
     companion object {
-        const val DEFAULT_DELIMITER = "/"
+        const val DEFAULT_DELIMITER = ","
         const val DEFAULT_IDLE_TIMEOUT_IN_MINUTES: Long = 5L
         const val DEFAULT_EVENTS_BEFORE_FRUSTRATION: Int = 5
         const val DEFAULT_FRUSTRATION_PROBABILITY: Int = 75

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -41,3 +41,4 @@ settings.personality.frustration.probability=Probability of Frustration Event
 settings.personality.frustration.enable=Allow Frustration
 settings.exit.code.events.notification=Show Notification
 settings.exit.code.events.sound=Play Sound
+settings.exit.code.allowed=Allowed Exit Codes

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -42,3 +42,4 @@ settings.personality.frustration.enable=Allow Frustration
 settings.exit.code.events.notification=Show Notification
 settings.exit.code.events.sound=Play Sound
 settings.exit.code.allowed=Allowed Exit Codes
+settings.exit.code.no.codes=No allowed exit codes.


### PR DESCRIPTION
# Motivation

Closes #192 

Rather than hard code values that should be allowed, I chose to start off with some defaults that can be modified by the users as they come across more exit codes.

![image](https://user-images.githubusercontent.com/15972415/93003751-e2afc380-f506-11ea-8264-15a06d720cbd.png)
