### PR TITLE
bug: enable plugin to work without IDE restart

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuMotivatorProject.java
@@ -20,6 +20,7 @@ import zd.zero.waifu.motivator.plugin.assets.VisualMotivationAssetProvider;
 import zd.zero.waifu.motivator.plugin.assets.WaifuAssetCategory;
 import zd.zero.waifu.motivator.plugin.listeners.ExitCodeListener;
 import zd.zero.waifu.motivator.plugin.listeners.IdleEventListener;
+import zd.zero.waifu.motivator.plugin.listeners.PluginInstallListener;
 import zd.zero.waifu.motivator.plugin.listeners.WaifuUnitTester;
 import zd.zero.waifu.motivator.plugin.motivation.VisualMotivationFactory;
 import zd.zero.waifu.motivator.plugin.motivation.WaifuMotivation;
@@ -96,7 +97,8 @@ public class WaifuMotivatorProject implements ProjectManagerListener, Disposable
         }
 
         if ( !getPluginState().isSayonaraEnabled() ||
-            areMultipleProjectsOpened() ) return;
+            areMultipleProjectsOpened() ||
+            PluginInstallListener.Companion.isRunningUpdate() ) return;
 
         AudibleAssetDefinitionService.INSTANCE.getRandomAssetByCategory(
             WaifuAssetCategory.DEPARTURE

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -2,12 +2,8 @@ package zd.zero.waifu.motivator.plugin.listeners
 
 import com.intellij.ide.plugins.DynamicPluginListener
 import com.intellij.ide.plugins.IdeaPluginDescriptor
-import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
-import com.intellij.openapi.project.ProjectManagerListener
 import zd.zero.waifu.motivator.plugin.WaifuMotivator
-import zd.zero.waifu.motivator.plugin.onboarding.UpdateNotification
-
 
 class PluginInstallListener : DynamicPluginListener {
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -52,11 +52,12 @@ class PluginInstallListener : DynamicPluginListener {
     override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
         if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
             ProjectManager.getInstance().openProjects.forEach {
-                UpdateNotification.sendMessage(
-                    "Ravioli Ravioli",
-                    "Give me the formuoli",
-                    it
-                )
+                ProjectManager.getInstance().reloadProject(it)
+//                UpdateNotification.sendMessage(
+//                    "Ravioli Ravioli",
+//                    "Give me the formuoli",
+//                    it
+//                )
 
             }
         }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -1,2 +1,30 @@
 package zd.zero.waifu.motivator.plugin.listeners
 
+import com.intellij.ide.plugins.DynamicPluginListener
+import com.intellij.ide.plugins.IdeaPluginDescriptor
+import zd.zero.waifu.motivator.plugin.WaifuMotivator
+import zd.zero.waifu.motivator.plugin.onboarding.UpdateNotification
+
+class PluginInstallListener : DynamicPluginListener {
+    override fun beforePluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
+    }
+
+    override fun beforePluginUnload(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
+    }
+
+    override fun checkUnloadPlugin(pluginDescriptor: IdeaPluginDescriptor) {
+    }
+
+    override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
+        if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
+            UpdateNotification.sendMessage(
+                "Ravioli Ravioli",
+                "Give me the formuoli"
+            )
+        }
+    }
+
+    override fun pluginUnloaded(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
+
+    }
+}

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -1,0 +1,2 @@
+package zd.zero.waifu.motivator.plugin.listeners
+

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -8,37 +8,12 @@ import com.intellij.openapi.project.ProjectManagerListener
 import zd.zero.waifu.motivator.plugin.WaifuMotivator
 import zd.zero.waifu.motivator.plugin.onboarding.UpdateNotification
 
-class MotivatorProject(private val project: Project) : ProjectManagerListener {
-
-    init {
-        UpdateNotification.sendMessage(
-            "Motivator Project",
-            "Instantiated",
-            project
-        )
-
-    }
-
-    override fun projectOpened(project: Project) {
-        UpdateNotification.sendMessage(
-            "Motivator Project",
-            "Project Opened",
-            this.project
-        )
-
-    }
-
-    override fun projectClosed(project: Project) {
-        UpdateNotification.sendMessage(
-            "Motivator Project",
-            "Project Closed",
-            this.project
-        )
-    }
-}
-
 
 class PluginInstallListener : DynamicPluginListener {
+
+    companion object {
+        var isRunningUpdate = false
+    }
 
     override fun beforePluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
     }
@@ -51,15 +26,11 @@ class PluginInstallListener : DynamicPluginListener {
 
     override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
         if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
+            isRunningUpdate = true
             ProjectManager.getInstance().openProjects.forEach {
                 ProjectManager.getInstance().reloadProject(it)
-//                UpdateNotification.sendMessage(
-//                    "Ravioli Ravioli",
-//                    "Give me the formuoli",
-//                    it
-//                )
-
             }
+            isRunningUpdate = false
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -2,16 +2,19 @@ package zd.zero.waifu.motivator.plugin.listeners
 
 import com.intellij.ide.plugins.DynamicPluginListener
 import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.project.ProjectManager
 import zd.zero.waifu.motivator.plugin.WaifuMotivator
 import zd.zero.waifu.motivator.plugin.onboarding.UpdateNotification
 
 class PluginInstallListener : DynamicPluginListener {
 
     init {
-        UpdateNotification.sendMessage(
-            "Ravioli Ravioli",
-            "Give me the formuoli"
-        )
+        ProjectManager.getInstance().openProjects.forEach {
+            UpdateNotification.sendMessage(
+                "threw it on the ground",
+                "What you think I'm stupid?"
+            )
+        }
     }
 
     override fun beforePluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
@@ -25,10 +28,14 @@ class PluginInstallListener : DynamicPluginListener {
 
     override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
         if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
-            UpdateNotification.sendMessage(
-                "threw it on the ground",
-                "What you think I'm stupid?"
-            )
+            ProjectManager.getInstance().openProjects.forEach {
+                UpdateNotification.sendMessage(
+                    "Ravioli Ravioli",
+                    "Give me the formuoli",
+                    it
+                )
+
+            }
         }
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -6,6 +6,14 @@ import zd.zero.waifu.motivator.plugin.WaifuMotivator
 import zd.zero.waifu.motivator.plugin.onboarding.UpdateNotification
 
 class PluginInstallListener : DynamicPluginListener {
+
+    init {
+        UpdateNotification.sendMessage(
+            "Ravioli Ravioli",
+            "Give me the formuoli"
+        )
+    }
+
     override fun beforePluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
     }
 
@@ -18,7 +26,7 @@ class PluginInstallListener : DynamicPluginListener {
     override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
         if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
             UpdateNotification.sendMessage(
-                "I threw it on the ground",
+                "threw it on the ground",
                 "What you think I'm stupid?"
             )
         }
@@ -26,10 +34,6 @@ class PluginInstallListener : DynamicPluginListener {
 
     override fun pluginUnloaded(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
         if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
-            UpdateNotification.sendMessage(
-                "Ravioli Ravioli",
-                "Give me the formuoli"
-            )
         }
     }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -18,13 +18,18 @@ class PluginInstallListener : DynamicPluginListener {
     override fun pluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
         if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
             UpdateNotification.sendMessage(
-                "Ravioli Ravioli",
-                "Give me the formuoli"
+                "I threw it on the ground",
+                "What you think I'm stupid?"
             )
         }
     }
 
     override fun pluginUnloaded(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
-
+        if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
+            UpdateNotification.sendMessage(
+                "Ravioli Ravioli",
+                "Give me the formuoli"
+            )
+        }
     }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/PluginInstallListener.kt
@@ -2,20 +2,43 @@ package zd.zero.waifu.motivator.plugin.listeners
 
 import com.intellij.ide.plugins.DynamicPluginListener
 import com.intellij.ide.plugins.IdeaPluginDescriptor
+import com.intellij.openapi.project.Project
 import com.intellij.openapi.project.ProjectManager
+import com.intellij.openapi.project.ProjectManagerListener
 import zd.zero.waifu.motivator.plugin.WaifuMotivator
 import zd.zero.waifu.motivator.plugin.onboarding.UpdateNotification
 
-class PluginInstallListener : DynamicPluginListener {
+class MotivatorProject(private val project: Project) : ProjectManagerListener {
 
     init {
-        ProjectManager.getInstance().openProjects.forEach {
-            UpdateNotification.sendMessage(
-                "threw it on the ground",
-                "What you think I'm stupid?"
-            )
-        }
+        UpdateNotification.sendMessage(
+            "Motivator Project",
+            "Instantiated",
+            project
+        )
+
     }
+
+    override fun projectOpened(project: Project) {
+        UpdateNotification.sendMessage(
+            "Motivator Project",
+            "Project Opened",
+            this.project
+        )
+
+    }
+
+    override fun projectClosed(project: Project) {
+        UpdateNotification.sendMessage(
+            "Motivator Project",
+            "Project Closed",
+            this.project
+        )
+    }
+}
+
+
+class PluginInstallListener : DynamicPluginListener {
 
     override fun beforePluginLoaded(pluginDescriptor: IdeaPluginDescriptor) {
     }
@@ -39,8 +62,5 @@ class PluginInstallListener : DynamicPluginListener {
         }
     }
 
-    override fun pluginUnloaded(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {
-        if (pluginDescriptor.pluginId.idString == WaifuMotivator.PLUGIN_ID) {
-        }
-    }
+    override fun pluginUnloaded(pluginDescriptor: IdeaPluginDescriptor, isUpdate: Boolean) {}
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -66,6 +66,8 @@
   <projectListeners>
     <listener class="zd.zero.waifu.motivator.plugin.WaifuMotivatorProject"
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    <listener class="zd.zero.waifu.motivator.plugin.listeners.MotivatorProject"
+              topic="com.intellij.openapi.project.ProjectManagerListener"/>
     <listener class="zd.zero.waifu.motivator.plugin.listeners.TaskListener"
               topic="com.intellij.task.ProjectTaskListener"/>
   </projectListeners>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -59,6 +59,10 @@
     </group>
   </actions>
 
+  <applicationListeners>
+    <listener class="zd.zero.waifu.motivator.plugin.listeners.PluginInstallListener"
+              topic="com.intellij.ide.plugins.DynamicPluginListener"/>
+  </applicationListeners>
   <projectListeners>
     <listener class="zd.zero.waifu.motivator.plugin.WaifuMotivatorProject"
               topic="com.intellij.openapi.project.ProjectManagerListener"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -66,8 +66,6 @@
   <projectListeners>
     <listener class="zd.zero.waifu.motivator.plugin.WaifuMotivatorProject"
               topic="com.intellij.openapi.project.ProjectManagerListener"/>
-    <listener class="zd.zero.waifu.motivator.plugin.listeners.MotivatorProject"
-              topic="com.intellij.openapi.project.ProjectManagerListener"/>
     <listener class="zd.zero.waifu.motivator.plugin.listeners.TaskListener"
               topic="com.intellij.task.ProjectTaskListener"/>
   </projectListeners>


### PR DESCRIPTION
# Motivation

Closes #198 

Lol, so this was a pain to simulate testing, however I think I narrowed it down to this quick fix.

I think that this can be done without having to reload each project though. It would require to have one Application Level listener that listens to project life-cycles instead of many project life-cycle listeners. However, I think this is good enough for the time being. Maybe that could be a target for 1.4 ?

Fun Fact: Project Listeners are not instantiated on plugin load.They only get instatiated when a relevant event is triggered. So it comes into existence when the project closes, but not when the plugin is first loaded :cry: 