### PR TITLE
chore: fix memory leak and added exit code debug log

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
@@ -6,6 +6,7 @@ import com.intellij.execution.process.ProcessHandler
 import com.intellij.execution.runners.ExecutionEnvironment
 import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
 import zd.zero.waifu.motivator.plugin.alert.AlertConfiguration
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
@@ -25,6 +26,7 @@ fun String.toExitCodes(): Set<Int> = this.split(DEFAULT_DELIMITER)
     .map { it.trim().toInt() }.toSet()
 
 class ExitCodeListener(private val project: Project) : Runnable, Disposable {
+    private val log = Logger.getInstance(javaClass)
     private val messageBus = ApplicationManager.getApplication().messageBus.connect()
 
     private var allowedExitCodes = WaifuMotivatorPluginState.getPluginState()
@@ -44,6 +46,7 @@ class ExitCodeListener(private val project: Project) : Runnable, Disposable {
                 handler: ProcessHandler,
                 exitCode: Int
             ) {
+                log.debug("Observed exit code of $exitCode")
                 if (allowedExitCodes.contains(exitCode).not() && env.project == project) {
                     run()
                 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.java
@@ -272,11 +272,6 @@ public class WaifuMotivatorSettingsPage implements SearchableConfigurable, Confi
 
         exitCodeTable.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
 
-        new CellTooltipManager(ApplicationService.INSTANCE).
-            withCellComponentProvider( CellComponentProvider.forTable( exitCodeTable )).
-            installOn( exitCodeTable );
-
-
         exitCodePanel = ToolbarDecorator.createDecorator( exitCodeTable )
             .disableUpDownActions().createPanel();
 


### PR DESCRIPTION
# Motivation

Closes #204 

# Notes

To enable debug logging to observe the exit code in the logs, all you have to do is use the `Help | Diagnostic Tools | Debug Log Settings..`
and add the line `#zd.zero.waifu.motivator.plugin.listeners.ExitCodeListener` to it.

Should that be added to the docs?