### PR TITLE
Bumping GitHub Action to latest version

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Verify Plugin on IntelliJ Platforms
       id: verify
-      uses: ChrisCarini/intellij-platform-plugin-verifier-action@v0.0.2
+      uses: ChrisCarini/intellij-platform-plugin-verifier-action@v1.0.3
       with:
         ide-versions: |
           ideaIC:2020.1


### PR DESCRIPTION
Bumping GitHub Action to latest released version, [release notes for v1.0.3 here](https://github.com/ChrisCarini/intellij-platform-plugin-verifier-action/releases/tag/v1.0.3).