### PR TITLE
fix: ui freezing on visual notifications

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/actions/MotivateMeAction.java
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/actions/MotivateMeAction.java
@@ -2,6 +2,7 @@ package zd.zero.waifu.motivator.plugin.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.project.DumbAware;
 import org.jetbrains.annotations.NotNull;
 import zd.zero.waifu.motivator.plugin.ProjectConstants;
@@ -28,24 +29,25 @@ public class MotivateMeAction extends AnAction implements DumbAware {
             pluginState.isMotivateMeEnabled(),
             pluginState.isMotivateMeSoundEnabled() );
 
-        doOrElse(
-            VisualMotivationAssetProvider.INSTANCE.pickAssetFromCategories(
-                WaifuAssetCategory.CELEBRATION,
-                WaifuAssetCategory.HAPPY,
-                WaifuAssetCategory.SMUG
-            ),
-            motivationAsset ->
-                VisualMotivationFactory.INSTANCE.constructNonTitledMotivation(
-                    Objects.requireNonNull( e.getProject() ),
-                    motivationAsset,
-                    config
-                ).motivate(),
-            () ->
-                UpdateNotification.INSTANCE.sendMessage(
-                    "'Motivate Me' Unavailable Offline",
-                    ProjectConstants.getWAIFU_UNAVAILABLE_MESSAGE(),
-                    e.getProject()
-                ) );
+        ApplicationManager.getApplication().executeOnPooledThread( () ->
+            doOrElse(
+                VisualMotivationAssetProvider.INSTANCE.pickAssetFromCategories(
+                    WaifuAssetCategory.CELEBRATION,
+                    WaifuAssetCategory.HAPPY,
+                    WaifuAssetCategory.SMUG
+                ),
+                motivationAsset ->
+                    VisualMotivationFactory.INSTANCE.constructNonTitledMotivation(
+                        Objects.requireNonNull( e.getProject() ),
+                        motivationAsset,
+                        config
+                    ).motivate(),
+                () ->
+                    UpdateNotification.INSTANCE.sendMessage(
+                        "'Motivate Me' Unavailable Offline",
+                        ProjectConstants.getWAIFU_UNAVAILABLE_MESSAGE(),
+                        e.getProject()
+                    ) ) );
     }
 
     @Override

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
@@ -43,22 +43,22 @@ abstract class RemoteAssetManager<T : AssetDefinition, U : Asset>(
 
     private fun initializeAssetCaches(assetFileUrl: Optional<String>, breakOnFailure: Boolean = true) {
         assetFileUrl
-                .flatMap { assetUrl -> initializeRemoteAssets(assetUrl) }
-                .doOrElse({ allAssetDefinitions ->
-                    status = Status.OK
-                    remoteAndLocalAssets = allAssetDefinitions
-                    localAssets = allAssetDefinitions.filter { asset ->
-                        AssetManager.constructLocalAssetPath(assetCategory, asset.path)
-                            .filter { Files.exists(it) }
-                            .isPresent
-                    }.toSet().toMutableSet()
-                }) {
-                    if (breakOnFailure) {
-                        status = Status.BROKEN
-                        remoteAndLocalAssets = listOf()
-                        localAssets = mutableSetOf()
-                    }
+            .flatMap { assetUrl -> initializeRemoteAssets(assetUrl) }
+            .doOrElse({ allAssetDefinitions ->
+                status = Status.OK
+                remoteAndLocalAssets = allAssetDefinitions
+                localAssets = allAssetDefinitions.filter { asset ->
+                    AssetManager.constructLocalAssetPath(assetCategory, asset.path)
+                        .filter { Files.exists(it) }
+                        .isPresent
+                }.toSet().toMutableSet()
+            }) {
+                if (breakOnFailure) {
+                    status = Status.BROKEN
+                    remoteAndLocalAssets = listOf()
+                    localAssets = mutableSetOf()
                 }
+            }
     }
 
     fun supplyAssetDefinitions(): List<T> =
@@ -66,6 +66,11 @@ abstract class RemoteAssetManager<T : AssetDefinition, U : Asset>(
 
     fun supplyLocalAssetDefinitions(): Set<T> =
         localAssets
+
+    fun supplyRemoteAssetDefinitions(): List<T> =
+        remoteAndLocalAssets.filterNot { remoteAndLocal ->
+            localAssets.toList().any { it.path == remoteAndLocal.path }
+        }
 
     abstract fun convertToAsset(asset: T, assetUrl: String): U
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
@@ -68,8 +68,8 @@ abstract class RemoteAssetManager<T : AssetDefinition, U : Asset>(
         localAssets
 
     fun supplyRemoteAssetDefinitions(): List<T> =
-        remoteAndLocalAssets.filterNot { remoteAndLocal ->
-            localAssets.toList().any { it.path == remoteAndLocal.path }
+        remoteAndLocalAssets.filterNot { remoteOrLocalAsset ->
+            localAssets.contains(remoteOrLocalAsset)
         }
 
     abstract fun convertToAsset(asset: T, assetUrl: String): U

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
@@ -61,9 +61,6 @@ abstract class RemoteAssetManager<T : AssetDefinition, U : Asset>(
             }
     }
 
-    fun supplyAssetDefinitions(): List<T> =
-        remoteAndLocalAssets
-
     fun supplyLocalAssetDefinitions(): Set<T> =
         localAssets
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/AssetTools.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/AssetTools.kt
@@ -1,5 +1,6 @@
 package zd.zero.waifu.motivator.plugin.tools
 
+import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.Project
 import zd.zero.waifu.motivator.plugin.alert.AlertConfiguration
 import zd.zero.waifu.motivator.plugin.assets.VisualMotivationAssetProvider
@@ -36,9 +37,11 @@ object AssetTools {
             VisualMotivationAssetProvider.pickAssetFromCategories(
                 *categories
             ).doOrElse({ asset ->
-                VisualMotivationFactory.constructMotivation(project,
-                    asset,
-                    alertConfigurationSupplier()).motivate()
+                ApplicationManager.getApplication().executeOnPooledThread {
+                    VisualMotivationFactory.constructMotivation(project,
+                        asset,
+                        alertConfigurationSupplier()).motivate()
+                }
             }) {
                 attemptToDisplayMotivation(
                     project,

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
@@ -34,7 +34,6 @@ class RemoteAssetDefinitionServiceTest {
 
     @Test
     fun `get random asset by category should return empty when no assets`() {
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf()
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf()
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf()
 
@@ -47,7 +46,6 @@ class RemoteAssetDefinitionServiceTest {
 
     @Test
     fun `get random asset by category should return local when no remote assets`() {
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf()
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } answers { callOriginal() }
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
@@ -78,7 +76,6 @@ class RemoteAssetDefinitionServiceTest {
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf()
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf()
@@ -99,7 +96,6 @@ class RemoteAssetDefinitionServiceTest {
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf(bestMotivation)
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf()
 
@@ -123,7 +119,6 @@ class RemoteAssetDefinitionServiceTest {
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf()
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
@@ -152,7 +147,6 @@ class RemoteAssetDefinitionServiceTest {
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
@@ -181,7 +175,6 @@ class RemoteAssetDefinitionServiceTest {
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
@@ -47,7 +47,7 @@ class RemoteAssetDefinitionServiceTest {
 
     @Test
     fun `get random asset by category should return local when no remote assets`() {
-        every { remoteAssetManager.supplyAssetDefinitions() }
+        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf()
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } answers { callOriginal() }
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
@@ -13,7 +13,11 @@ import java.util.*
 
 internal class FakeVisualAssetDefinitionService(
     assetManager: RemoteAssetManager<VisualMotivationAssetDefinition, VisualMotivationAsset>
-) : RemoteAssetDefinitionService<VisualMotivationAssetDefinition, VisualMotivationAsset>(assetManager)
+) : RemoteAssetDefinitionService<VisualMotivationAssetDefinition, VisualMotivationAsset>(assetManager) {
+    override fun downloadNewAsset(waifuAssetCategory: WaifuAssetCategory) {
+        // do nothing
+    }
+}
 
 class RemoteAssetDefinitionServiceTest {
 
@@ -29,9 +33,10 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnEmptyWhenNoAssets() {
+    fun `get random asset by category should return empty when no assets`() {
         every { remoteAssetManager.supplyAssetDefinitions() } returns listOf()
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf()
+        every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf()
 
         val randomAsset = fakeVisualAssetDefinitionService.getRandomAssetByCategory(
             WaifuAssetCategory.MOTIVATION
@@ -41,8 +46,9 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnLocalWhenNoRemoteAssets() {
-        every { remoteAssetManager.supplyAssetDefinitions() } returns listOf()
+    fun `get random asset by category should return local when no remote assets`() {
+        every { remoteAssetManager.supplyAssetDefinitions() }
+        every { remoteAssetManager.supplyRemoteAssetDefinitions() } answers { callOriginal() }
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
@@ -64,7 +70,7 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnEmptyWhenUnableToFetchRemoteAssetWithNoLocalAssets() {
+    fun `get random asset by category should return empty when unable to fetch remote asset with no local assets`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
             "Ryuko",
@@ -73,6 +79,7 @@ class RemoteAssetDefinitionServiceTest {
             listOf(WaifuAssetCategory.MOTIVATION)
         )
         every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
+        every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf()
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf()
 
@@ -84,7 +91,7 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnRemoteWhenAvailable() {
+    fun `get random asset by category should return remote when available`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
             "Ryuko",
@@ -93,6 +100,8 @@ class RemoteAssetDefinitionServiceTest {
             listOf(WaifuAssetCategory.MOTIVATION)
         )
         every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
+        every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf(bestMotivation)
+        every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf()
 
         val expectedAsset = bestMotivation.toAsset("file:///s-tier-waifus/ryuko.png")
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns expectedAsset.deepClonePolymorphic()
@@ -106,7 +115,7 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnEmptyWhenUnableToFetchRemoteAssetWithNoMatchingLocalAssets() {
+    fun `get random asset by category should return empty when unable to fetch remote asset with no matching local assets`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
             "Ryuko",
@@ -115,6 +124,7 @@ class RemoteAssetDefinitionServiceTest {
             listOf(WaifuAssetCategory.MOTIVATION)
         )
         every { remoteAssetManager.supplyAssetDefinitions() } returns listOf(bestMotivation)
+        every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf()
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
         val garbageWaifu = VisualMotivationAssetDefinition(
@@ -134,7 +144,7 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnEmptyWhenLocalAssetIsNotLocal() {
+    fun `get random asset by category should return empty when local asset is not local`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
             "Ryuko",
@@ -163,7 +173,7 @@ class RemoteAssetDefinitionServiceTest {
     }
 
     @Test
-    fun getRandomAssetByCategoryShouldReturnLocalAssetRemoteAssetIsNotAvailable() {
+    fun `get random asset by category should return local asset remote asset is not available`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
             "Ryuko",

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManagerTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManagerTest.kt
@@ -49,7 +49,6 @@ class RemoteAssetManagerTest {
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.BROKEN)
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).isEmpty()
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).isEmpty()
     }
 
     @Test
@@ -66,7 +65,6 @@ class RemoteAssetManagerTest {
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.BROKEN)
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).isEmpty()
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).isEmpty()
     }
 
     @Test
@@ -82,13 +80,6 @@ class RemoteAssetManagerTest {
         val fakeAssetManager = FakeAssetManager()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(
@@ -122,13 +113,6 @@ class RemoteAssetManagerTest {
         val fakeAssetManager = FakeAssetManager()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(
@@ -145,13 +129,6 @@ class RemoteAssetManagerTest {
         listenerSlot.captured.onRequestedUpdate()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(
@@ -186,13 +163,6 @@ class RemoteAssetManagerTest {
         val fakeAssetManager = FakeAssetManager()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(
@@ -209,13 +179,6 @@ class RemoteAssetManagerTest {
         listenerSlot.captured.onRequestedUpdate()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(
@@ -250,13 +213,6 @@ class RemoteAssetManagerTest {
         val fakeAssetManager = FakeAssetManager()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(
@@ -273,15 +229,6 @@ class RemoteAssetManagerTest {
         listenerSlot.captured.onRequestedUpdate()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
-        assertThat(fakeAssetManager.supplyAssetDefinitions()).extracting("path")
-            .containsExactlyInAnyOrder(
-                "waiting/kanna_bored.gif",
-                "waiting/konata_bored_one.gif",
-                "waiting/misato_bored_one.gif",
-                "waiting/ryuko_waiting.gif",
-                "aqua_celebration.gif",
-                "celebration/caramelldansen.gif"
-            )
 
         assertThat(fakeAssetManager.supplyLocalAssetDefinitions()).extracting("path")
             .containsExactlyInAnyOrder(

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManagerTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManagerTest.kt
@@ -95,6 +95,12 @@ class RemoteAssetManagerTest {
                 "waiting/konata_bored_one.gif",
                 "waiting/ryuko_waiting.gif"
             )
+
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif"
+            )
     }
 
     @Test
@@ -130,6 +136,12 @@ class RemoteAssetManagerTest {
                 "waiting/ryuko_waiting.gif"
             )
 
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif"
+            )
+
         listenerSlot.captured.onRequestedUpdate()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
@@ -145,6 +157,12 @@ class RemoteAssetManagerTest {
             .containsExactlyInAnyOrder(
                 "waiting/konata_bored_one.gif",
                 "waiting/ryuko_waiting.gif"
+            )
+
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif"
             )
     }
 
@@ -182,6 +200,12 @@ class RemoteAssetManagerTest {
                 "waiting/ryuko_waiting.gif"
             )
 
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif"
+            )
+
         listenerSlot.captured.onRequestedUpdate()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
@@ -197,6 +221,12 @@ class RemoteAssetManagerTest {
             .containsExactlyInAnyOrder(
                 "waiting/konata_bored_one.gif",
                 "waiting/ryuko_waiting.gif"
+            )
+
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif"
             )
     }
 
@@ -234,6 +264,12 @@ class RemoteAssetManagerTest {
                 "waiting/ryuko_waiting.gif"
             )
 
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif"
+            )
+
         listenerSlot.captured.onRequestedUpdate()
 
         assertThat(fakeAssetManager.status).isEqualTo(Status.OK)
@@ -252,6 +288,13 @@ class RemoteAssetManagerTest {
                 "waiting/konata_bored_one.gif",
                 "waiting/ryuko_waiting.gif",
                 "celebration/caramelldansen.gif"
+            )
+
+        assertThat(fakeAssetManager.supplyRemoteAssetDefinitions()).extracting("path")
+            .containsExactlyInAnyOrder(
+                "waiting/kanna_bored.gif",
+                "waiting/misato_bored_one.gif",
+                "aqua_celebration.gif"
             )
     }
 }


### PR DESCRIPTION
This PR resolves the freezing of UI, as this will prioritize local assets, and every time an event is triggered it'll run a background task to fetch a new asset. For the first asset category, it'll fallback to original behavior to download and use the asset, but it's running on a separate thread so this won't block the EDT.

You can now spam the *Waifus* without delay!
![no ui freeze demo](https://user-images.githubusercontent.com/21978370/94314148-8b9ff900-ffb2-11ea-9bcb-d1fd7bf4c46e.gif)
