### PR TITLE
chore(gradle): revert changelog extension from html to md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,5 @@ gradle-app.setting
 !.idea/waifu-motivator-plugin.iml
 !.idea/codeStyles/*
 !.idea/runConfigurations/*
+
+.java-version

--- a/build.gradle
+++ b/build.gradle
@@ -79,4 +79,5 @@ patchPluginXml {
 
 tasks.markdownToHtml.dependsOn("createReleaseNotes")
 tasks.markdownToHtml.dependsOn("copyPluginDescription")
-tasks.patchPluginXml.dependsOn("markdownToHtml")
+tasks.htmlToMarkdownExtension.dependsOn("markdownToHtml")
+tasks.patchPluginXml.dependsOn("htmlToMarkdownExtension")

--- a/buildSrc/src/main/kotlin/BuildTools.kt
+++ b/buildSrc/src/main/kotlin/BuildTools.kt
@@ -4,14 +4,16 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 fun createMarkdownDirectory(project: Project): Path =
-  buildDirectory(project, "markdown")
+    buildDirectory(project)
 
-private fun buildDirectory(project: Project, html: String): Path {
-  val markdownPath = Paths.get(
-    project.rootDir.absolutePath,
-    "build",
-    html
-  )
-  Files.createDirectories(markdownPath)
-  return markdownPath
+private fun buildDirectory(project: Project, dir: String = "markdown"): Path {
+    val markdownPath = Paths.get(
+        getBuildDirectory(project).toString(),
+        dir
+    )
+    Files.createDirectories(markdownPath)
+    return markdownPath
 }
+
+fun getBuildDirectory(project: Project): Path =
+    Paths.get(project.rootDir.absolutePath, "build")

--- a/buildSrc/src/main/kotlin/CreateReleaseNotes.kt
+++ b/buildSrc/src/main/kotlin/CreateReleaseNotes.kt
@@ -5,23 +5,24 @@ import java.nio.file.Paths
 
 open class CreateReleaseNotes : DefaultTask() {
 
-  init {
-    group = "documentation"
-    description = "Creates release notes from system env set by pipeline"
-  }
-
-  @TaskAction
-  fun run() {
-    val markdownDir = createMarkdownDirectory(project)
-    Files.newBufferedWriter(
-      Paths.get(markdownDir.toString(), "RELEASE-NOTES.md")
-    ).use {
-      it.write(System.getenv().getOrDefault(
-        "RELEASE_NOTES",
-        "No release notes available"
-      ))
-        it.write("""
-For more information [please see the changelog.](https://github.com/zd-zero/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md)""")
+    init {
+        group = "documentation"
+        description = "Creates release notes from system env set by pipeline"
     }
-  }
+
+    @TaskAction
+    fun run() {
+        val markdownDir = createMarkdownDirectory(project)
+        Files.newBufferedWriter(
+            Paths.get(markdownDir.toString(), "RELEASE-NOTES.md")
+        ).use {
+            it.write(System.getenv().getOrDefault(
+                "RELEASE_NOTES",
+                "No release notes available"
+            ))
+            it.write("""
+
+For more information please [see the changelog](https://github.com/zd-zero/waifu-motivator-plugin/blob/master/docs/CHANGELOG.md).""")
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/HtmlToMdExtension.kt
+++ b/buildSrc/src/main/kotlin/HtmlToMdExtension.kt
@@ -1,0 +1,30 @@
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.stream.Collectors.joining
+
+open class HtmlToMdExtension : DefaultTask() {
+
+    init {
+        group = "documentation"
+        description = "Reverts back the md extension"
+    }
+
+    @TaskAction
+    fun run() {
+        val releaseNotes = Paths.get(
+            getBuildDirectory(project).toString(),
+            "html",
+            "RELEASE-NOTES.html"
+        )
+
+        Files.newBufferedWriter(releaseNotes).use {
+            it.write(
+                Files.newBufferedReader(releaseNotes).lines()
+                    .map { l -> l.replace(".html", ".md") }
+                    .collect(joining("\n"))
+            )
+        }
+    }
+}

--- a/buildSrc/src/main/kotlin/waifu-motivator-build-plugin.gradle.kts
+++ b/buildSrc/src/main/kotlin/waifu-motivator-build-plugin.gradle.kts
@@ -1,2 +1,3 @@
 tasks.register("createReleaseNotes", CreateReleaseNotes::class.java)
 tasks.register("copyPluginDescription", CopyPluginDescription::class.java)
+tasks.register("htmlToMarkdownExtension", HtmlToMdExtension::class.java)


### PR DESCRIPTION
This PR reverts the changelog's content with `.html` extension back to `.md` as the plugin `'org.kordamp.gradle.markdown'` converts it to the target extension during the md to HTML process.