### PR TITLE
fix: multi-thread safe asset check serialization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,12 @@ intellij {
     println "Building for IntelliJ version: ${version}"
 
     alternativeIdePath idePath
+
+    if ("DOKI" == System.getenv("DEV_ENV")) {
+        setPlugins(
+            'io.acari.DDLCTheme:11.0.0'
+        )
+    }
 }
 
 compileKotlin {


### PR DESCRIPTION
# Motivation

Closes #229 

# Notes

The `LocalAssetService` is a singleton and now that asset downloading can happen in many threads, there are edge cases where on thread is writing to the asset check map while the other is trying to serialize it into json. So I chose to change the map to a `ConcurrentMap` so that the asset check can be written to and updated at the same time.

See this [issue for more details](https://github.com/google/gson/issues/1159#issuecomment-330535301)