### PR TITLE
feat: settings for number of invocations before alert

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/service/MotivationStatistics.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/service/MotivationStatistics.kt
@@ -1,0 +1,53 @@
+package zd.zero.waifu.motivator.plugin.service
+
+import com.intellij.openapi.components.PersistentStateComponent
+import com.intellij.openapi.components.RoamingType
+import com.intellij.openapi.components.State
+import com.intellij.openapi.components.Storage
+import com.intellij.util.xmlb.XmlSerializerUtil
+import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
+import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvents
+import java.util.*
+
+@State(
+    name = "WaifuMotivatorPluginStatistics",
+    storages = [
+        Storage(
+            value = "waifu-motivator-plugin-statistics.xml",
+            roamingType = RoamingType.DISABLED
+        )
+    ]
+)
+class MotivationStatistics : PersistentStateComponent<MotivationStatistics> {
+
+    companion object {
+        const val DEFAULT_STATISTICS_VALUE = 0
+
+        private val eventTypesToRegister = setOf(MotivationEvents.TASK, MotivationEvents.TEST)
+    }
+
+    private val statistics: MutableMap<MotivationEvents, Int> =
+        Collections.synchronizedMap(EnumMap(MotivationEvents::class.java))
+
+    fun registerEvent(event: MotivationEvent) {
+        if (eventTypesToRegister.contains(event.type).not()) return
+
+        synchronized(statistics) {
+            var eventCount = statistics.getOrDefault(event.type, DEFAULT_STATISTICS_VALUE)
+            eventCount++
+            statistics.put(event.type, eventCount)
+        }
+    }
+
+    fun getEventStat(event: MotivationEvents): Int = statistics.getOrDefault(event, DEFAULT_STATISTICS_VALUE)
+
+    fun resetStatistics() {
+        statistics.clear()
+    }
+
+    override fun getState(): MotivationStatistics? = this
+
+    override fun loadState(state: MotivationStatistics) {
+        XmlSerializerUtil.copyBean(state, this)
+    }
+}

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorSettingsPage.form
@@ -276,7 +276,7 @@
                       </vspacer>
                     </children>
                   </grid>
-                  <grid id="b2949" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="b2949" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="8" right="0"/>
                     <constraints>
                       <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
@@ -308,6 +308,25 @@
                           <text resource-bundle="messages/MessageBundle" key="settings.events.task"/>
                         </properties>
                       </component>
+                      <component id="37937" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="messages/MessageBundle" key="settings.task.events.before.notification"/>
+                        </properties>
+                      </component>
+                      <component id="9665a" class="javax.swing.JSpinner" binding="eventsBeforeTaskMotivationSpinner">
+                        <constraints>
+                          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                      </component>
+                      <hspacer id="c464">
+                        <constraints>
+                          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                      </hspacer>
                     </children>
                   </grid>
                   <grid id="d1ca5" layout-manager="GridLayoutManager" row-count="4" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
@@ -361,14 +380,11 @@
                     <properties/>
                     <border type="etched" title-resource-bundle="messages/MessageBundle" title-key="settings.events.idle"/>
                     <children>
-                      <hspacer id="55383">
-                        <constraints>
-                          <grid row="0" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
-                        </constraints>
-                      </hspacer>
                       <component id="977c8" class="javax.swing.JCheckBox" binding="enableIdleSoundCheckBox" default-binding="true">
                         <constraints>
-                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="1" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                            <preferred-size width="414" height="24"/>
+                          </grid>
                         </constraints>
                         <properties>
                           <text resource-bundle="messages/MessageBundle" key="settings.idle.sound"/>
@@ -376,13 +392,17 @@
                       </component>
                       <component id="28213" class="javax.swing.JSpinner" binding="idleTimeoutSpinner">
                         <constraints>
-                          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false"/>
+                          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="0" use-parent-layout="false">
+                            <preferred-size width="414" height="32"/>
+                          </grid>
                         </constraints>
                         <properties/>
                       </component>
                       <component id="682d2" class="javax.swing.JLabel">
                         <constraints>
-                          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                            <preferred-size width="414" height="16"/>
+                          </grid>
                         </constraints>
                         <properties>
                           <text resource-bundle="messages/MessageBundle" key="settings.idle.timeout"/>
@@ -390,16 +410,23 @@
                       </component>
                       <component id="4636e" class="javax.swing.JCheckBox" binding="enableIdleNotificationCheckBox" default-binding="true">
                         <constraints>
-                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                          <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false">
+                            <preferred-size width="414" height="24"/>
+                          </grid>
                         </constraints>
                         <properties>
                           <selected value="false"/>
                           <text resource-bundle="messages/MessageBundle" key="settings.idle.notification"/>
                         </properties>
                       </component>
+                      <hspacer id="ccdbe">
+                        <constraints>
+                          <grid row="3" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                      </hspacer>
                     </children>
                   </grid>
-                  <grid id="827f0" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+                  <grid id="827f0" layout-manager="GridLayoutManager" row-count="5" column-count="2" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
                     <margin top="0" left="0" bottom="8" right="0"/>
                     <constraints>
                       <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -433,6 +460,25 @@
                           <toolTipText resource-bundle="messages/MessageBundle" key="settings.unit.testing.sound.tooltip"/>
                         </properties>
                       </component>
+                      <component id="722ab" class="javax.swing.JLabel">
+                        <constraints>
+                          <grid row="3" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="0" anchor="8" fill="0" indent="1" use-parent-layout="false"/>
+                        </constraints>
+                        <properties>
+                          <text resource-bundle="messages/MessageBundle" key="settings.unit.testing.events.before.notification"/>
+                        </properties>
+                      </component>
+                      <component id="ee0a5" class="javax.swing.JSpinner" binding="eventsBeforeTestMotivationSpinner">
+                        <constraints>
+                          <grid row="4" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="6" anchor="8" fill="1" indent="1" use-parent-layout="false"/>
+                        </constraints>
+                        <properties/>
+                      </component>
+                      <hspacer id="3507b">
+                        <constraints>
+                          <grid row="4" column="1" row-span="1" col-span="1" vsize-policy="1" hsize-policy="6" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
+                        </constraints>
+                      </hspacer>
                     </children>
                   </grid>
                 </children>

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/WaifuMotivatorState.kt
@@ -2,6 +2,7 @@ package zd.zero.waifu.motivator.plugin.settings
 
 import zd.zero.waifu.motivator.plugin.listeners.FORCE_KILLED_EXIT_CODE
 import zd.zero.waifu.motivator.plugin.listeners.OK_EXIT_CODE
+import zd.zero.waifu.motivator.plugin.service.MotivationStatistics.Companion.DEFAULT_STATISTICS_VALUE
 
 class WaifuMotivatorState {
     companion object {
@@ -46,6 +47,10 @@ class WaifuMotivatorState {
     var isAllowFrustration = true
 
     var eventsBeforeFrustration = DEFAULT_EVENTS_BEFORE_FRUSTRATION
+
+    var eventsBeforeTestMotivation = DEFAULT_STATISTICS_VALUE
+
+    var eventsBeforeTaskMotivation = DEFAULT_STATISTICS_VALUE
 
     var probabilityOfFrustration = DEFAULT_FRUSTRATION_PROBABILITY
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,6 +16,8 @@
   <extensions defaultExtensionNs="com.intellij">
     <applicationService
       serviceImplementation="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState"/>
+    <applicationService
+      serviceImplementation="zd.zero.waifu.motivator.plugin.service.MotivationStatistics"/>
     <applicationConfigurable
       instance="zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorSettingsPage"/>
     <errorHandler

--- a/src/main/resources/messages/MessageBundle.properties
+++ b/src/main/resources/messages/MessageBundle.properties
@@ -48,6 +48,7 @@ settings.startup.sound.tooltip=Plays a motivation sound on startup immediately a
 settings.events.task=Task Event
 settings.task.events.notification=Task notification
 settings.task.events.sound=Task sound
+settings.task.events.before.notification=Tasks Events before a notification is shown
 
 ### Unit Testing Event
 settings.events.unit.testing=Unit Testing Event
@@ -55,6 +56,7 @@ settings.unit.testing.notification=Unit Testing notification
 settings.unit.testing.notification.tooltip=A notification is triggered whenever a unit test passes or fails
 settings.unit.testing.sound=Unit Testing sound
 settings.unit.testing.sound.tooltip=A sound motivation is triggered whenever a unit test passes or fails..
+settings.unit.testing.events.before.notification=Unit Testing Events before a notification is shown
 
 ### Idle Event
 settings.events.idle=Idle Event


### PR DESCRIPTION
This PR adds a setting to only invoke `TASK` and `TEST` motivation event types and keeps the number of occurrences and only invoke it after some number of events. The default is `0` which will always invoke the alert for each event.

<img width="752" alt="Screen Shot 2020-10-14 at 07 37 46" src="https://user-images.githubusercontent.com/21978370/95927175-a535a300-0df0-11eb-9ace-353bb6b19a08.png">
