### PR TITLE
chore: bump ktlint to 9.4.1

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -7,6 +7,22 @@
         <value />
       </option>
     </JavaCodeStyleSettings>
+    <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+    </JetCodeStyleSettings>
     <codeStyleSettings language="JAVA">
       <option name="BLANK_LINES_AROUND_FIELD" value="1" />
       <option name="BLANK_LINES_AROUND_FIELD_IN_INTERFACE" value="1" />

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'org.jetbrains.intellij' version '0.4.18'
     id 'io.franzbecker.gradle-lombok' version '3.3.0'
     id 'org.jetbrains.kotlin.jvm' version '1.4.0'
-    id "org.jlleitschuh.gradle.ktlint" version "8.2.0"
+    id "org.jlleitschuh.gradle.ktlint" version "9.4.1"
     id 'org.kordamp.gradle.markdown' version '2.2.0'
 }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/ProjectConstants.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/ProjectConstants.kt
@@ -3,6 +3,7 @@ package zd.zero.waifu.motivator.plugin
 object ProjectConstants {
 
     @JvmStatic
-    val WAIFU_UNAVAILABLE_MESSAGE = """Unfortunately I wasn't able to find any waifu saved locally.
+    val WAIFU_UNAVAILABLE_MESSAGE =
+        """Unfortunately I wasn't able to find any waifu saved locally.
     |Please try again when you are back online!""".trimMargin()
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/WaifuOfTheDayStartupActivity.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/WaifuOfTheDayStartupActivity.kt
@@ -24,12 +24,16 @@ class WaifuOfTheDayStartupActivity : StartupActivity.DumbAware {
         updatePlatformTipOfTheDayConfig()
 
         val disposableRef = AtomicReference<Disposable?>()
-        val future = EdtScheduledExecutorService.getInstance().schedule({
-            val disposable = disposableRef.getAndSet(null) ?: return@schedule
-            Disposer.dispose(disposable)
+        val future = EdtScheduledExecutorService.getInstance().schedule(
+            {
+                val disposable = disposableRef.getAndSet(null) ?: return@schedule
+                Disposer.dispose(disposable)
 
-            if (!project.isDisposed) WaifuOfTheDayDialog.canBeShownToday(project)
-        }, 0, TimeUnit.SECONDS)
+                if (!project.isDisposed) WaifuOfTheDayDialog.canBeShownToday(project)
+            },
+            0,
+            TimeUnit.SECONDS
+        )
 
         val disposable = Disposable {
             disposableRef.set(null)

--- a/src/main/java/zd/zero/waifu/motivator/plugin/actions/MotivateMeAction.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/actions/MotivateMeAction.kt
@@ -11,7 +11,7 @@ import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEventCategory
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvents
 import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState
-import java.util.*
+import java.util.Objects
 
 class MotivateMeAction : AnAction(WaifuMotivatorIcons.MENU), DumbAware {
     override fun actionPerformed(e: AnActionEvent) {
@@ -19,7 +19,8 @@ class MotivateMeAction : AnAction(WaifuMotivatorIcons.MENU), DumbAware {
         val config = AlertConfiguration(
             pluginState.isMotivateMeEnabled || pluginState.isMotivateMeSoundEnabled,
             pluginState.isMotivateMeEnabled,
-            pluginState.isMotivateMeSoundEnabled)
+            pluginState.isMotivateMeSoundEnabled
+        )
         showUntitledMotivationEventFromCategories(
             MotivationEvent(
                 MotivationEvents.MISC,

--- a/src/main/java/zd/zero/waifu/motivator/plugin/actions/RelaxAction.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/actions/RelaxAction.kt
@@ -6,8 +6,8 @@ import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.project.DumbAware
 import zd.zero.waifu.motivator.plugin.personality.core.emotions.EMOTIONAL_MUTATION_TOPIC
 import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionalMutationAction
-import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionalMutationType.*
-import zd.zero.waifu.motivator.plugin.personality.core.emotions.MoodCategory.*
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionalMutationType.RESET
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.MoodCategory.NEGATIVE
 
 class RelaxAction : AnAction(), DumbAware {
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/BaseWaifuNotification.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/BaseWaifuNotification.kt
@@ -12,7 +12,9 @@ abstract class BaseWaifuNotification(
 
     companion object {
         val notificationGroup = NotificationGroup(
-            WaifuMotivator.PLUGIN_NAME, NotificationDisplayType.BALLOON, false
+            WaifuMotivator.PLUGIN_NAME,
+            NotificationDisplayType.BALLOON,
+            false
         )
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/alert/NonTitledVisualNotification.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/alert/NonTitledVisualNotification.kt
@@ -9,5 +9,5 @@ class NonTitledVisualNotification(motivationAsset: MotivationAsset, project: Pro
 
     override fun buildNotification(): Notification =
         notificationGroup.createNotification()
-        .setContent(motivationAsset.message.ifEmpty { "" })
+            .setContent(motivationAsset.message.ifEmpty { "" })
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetManager.kt
@@ -16,7 +16,7 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 import java.nio.file.StandardOpenOption
-import java.util.*
+import java.util.Optional
 import java.util.concurrent.TimeUnit
 
 enum class AssetCategory(val category: String) {
@@ -64,7 +64,8 @@ object AssetManager {
         constructLocalAssetPath(assetCategory, assetPath)
             .flatMap {
                 val remoteAssetUrl = constructRemoteAssetUrl(
-                    assetCategory, assetPath
+                    assetCategory,
+                    assetPath
                 )
                 resolveAsset(it, remoteAssetUrl)
             }
@@ -95,7 +96,9 @@ object AssetManager {
         getLocalAssetDirectory()
             .map { localInstallDirectory ->
                 Paths.get(
-                    localInstallDirectory, assetCategory.category, assetPath
+                    localInstallDirectory,
+                    assetCategory.category,
+                    assetPath
                 ).normalize().toAbsolutePath()
             }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetModels.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetModels.kt
@@ -29,7 +29,11 @@ data class VisualMotivationAssetDefinition(
 ) : AssetDefinition {
     fun toAsset(assetUrl: String): VisualMotivationAsset =
         VisualMotivationAsset(
-            assetUrl, imageAlt, imageDimensions, groupId, characters
+            assetUrl,
+            imageAlt,
+            imageDimensions,
+            groupId,
+            characters
         )
 }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/AudibleAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/AudibleAssetManager.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.diagnostic.Logger
 import zd.zero.waifu.motivator.plugin.tools.ExceptionTools.runSafely
 import java.net.URI
 import java.nio.file.Paths
-import java.util.*
+import java.util.Optional
 
 object AudibleAssetManager : RemoteAssetManager<AudibleMotivationAssetDefinition, AudibleMotivationAsset>(
     AssetCategory.AUDIBLE
@@ -24,7 +24,8 @@ object AudibleAssetManager : RemoteAssetManager<AudibleMotivationAssetDefinition
     override fun convertToDefinitions(defJson: String): Optional<List<AudibleMotivationAssetDefinition>> =
         runSafely({
             Gson().fromJson<List<AudibleMotivationAssetDefinition>>(
-                defJson, object : TypeToken<List<AudibleMotivationAssetDefinition>>() {}.type
+                defJson,
+                object : TypeToken<List<AudibleMotivationAssetDefinition>>() {}.type
             )
         }) {
             log.warn("Unable to read Audible Assets for reasons $defJson", it)

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalStorageService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/LocalStorageService.kt
@@ -6,7 +6,7 @@ import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
-import java.util.*
+import java.util.Optional
 
 object LocalStorageService {
     private val log = Logger.getInstance(this::class.java)
@@ -21,7 +21,7 @@ object LocalStorageService {
 
     fun getLocalAssetDirectory(): Optional<String> =
         Optional.ofNullable(
-                PathManager.getConfigPath()
+            PathManager.getConfigPath()
         ).map {
             Paths.get(it, "waifuMotivationAssets").toAbsolutePath().toString()
         }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionService.kt
@@ -3,7 +3,8 @@ package zd.zero.waifu.motivator.plugin.assets
 import com.google.common.annotations.VisibleForTesting
 import com.intellij.openapi.application.ApplicationManager
 import zd.zero.waifu.motivator.plugin.tools.toOptional
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 import kotlin.random.Random
 
 abstract class RemoteAssetDefinitionService<T : AssetDefinition, U : Asset>(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
@@ -7,7 +7,7 @@ import zd.zero.waifu.motivator.plugin.tools.doOrElse
 import java.net.URI
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.util.*
+import java.util.Optional
 import java.util.Optional.ofNullable
 
 enum class Status {
@@ -29,16 +29,19 @@ abstract class RemoteAssetManager<T : AssetDefinition, U : Asset>(
 
     init {
         initializeAssetCaches(AssetManager.resolveAssetUrl(assetCategory, "assets.json"))
-        LifeCycleManager.registerUpdateListener(object : UpdateAssetsListener {
-            override fun onRequestedUpdate() {
-                initializeAssetCaches(
-                    AssetManager.forceResolveAssetUrl(
-                        assetCategory, "assets.json"
-                    ),
-                    breakOnFailure = false
-                )
+        LifeCycleManager.registerUpdateListener(
+            object : UpdateAssetsListener {
+                override fun onRequestedUpdate() {
+                    initializeAssetCaches(
+                        AssetManager.forceResolveAssetUrl(
+                            assetCategory,
+                            "assets.json"
+                        ),
+                        breakOnFailure = false
+                    )
+                }
             }
-        })
+        )
     }
 
     private fun initializeAssetCaches(assetFileUrl: Optional<String>, breakOnFailure: Boolean = true) {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/TextAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/TextAssetManager.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.diagnostic.Logger
 import zd.zero.waifu.motivator.plugin.tools.ExceptionTools
 import java.net.URI
 import java.nio.file.Paths
-import java.util.*
+import java.util.Optional
 
 object TextAssetManager : RemoteAssetManager<TextualMotivationAssetDefinition, TextualMotivationAssetPackage>(
     AssetCategory.TEXT
@@ -24,7 +24,8 @@ object TextAssetManager : RemoteAssetManager<TextualMotivationAssetDefinition, T
     override fun convertToDefinitions(defJson: String): Optional<List<TextualMotivationAssetDefinition>> =
         ExceptionTools.runSafely({
             Gson().fromJson<List<TextualMotivationAssetDefinition>>(
-                defJson, object : TypeToken<List<TextualMotivationAssetDefinition>>() {}.type
+                defJson,
+                object : TypeToken<List<TextualMotivationAssetDefinition>>() {}.type
             )
         }) {
             log.warn("Unable to read Text Assets for reasons $defJson", it)

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/TextAssetService.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/TextAssetService.kt
@@ -7,7 +7,8 @@ import zd.zero.waifu.motivator.plugin.tools.ExceptionTools.runSafely
 import zd.zero.waifu.motivator.plugin.tools.toOptional
 import java.io.BufferedReader
 import java.nio.file.Files
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.random.Random
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualAssetManager.kt
@@ -6,7 +6,7 @@ import com.intellij.openapi.diagnostic.Logger
 import zd.zero.waifu.motivator.plugin.assets.AssetCategory.VISUAL
 import zd.zero.waifu.motivator.plugin.service.WaifuGatekeeper
 import zd.zero.waifu.motivator.plugin.tools.ExceptionTools.runSafely
-import java.util.*
+import java.util.Optional
 
 object VisualAssetManager : RemoteAssetManager<VisualMotivationAssetDefinition, VisualMotivationAsset>(
     VISUAL
@@ -36,7 +36,8 @@ object VisualAssetManager : RemoteAssetManager<VisualMotivationAssetDefinition, 
     override fun convertToDefinitions(defJson: String): Optional<List<VisualMotivationAssetDefinition>> =
         runSafely({
             Gson().fromJson<List<VisualMotivationAssetDefinition>>(
-                defJson, object : TypeToken<List<VisualMotivationAssetDefinition>>() {}.type
+                defJson,
+                object : TypeToken<List<VisualMotivationAssetDefinition>>() {}.type
             )
         }) {
             log?.warn("Unable to read Visual Assets for reasons $defJson", it)

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProvider.kt
@@ -2,7 +2,7 @@ package zd.zero.waifu.motivator.plugin.assets
 
 import zd.zero.waifu.motivator.plugin.tools.allOf
 import zd.zero.waifu.motivator.plugin.tools.toOptional
-import java.util.*
+import java.util.Optional
 import kotlin.random.Random
 
 enum class WaifuAssetCategory {
@@ -67,10 +67,12 @@ object VisualMotivationAssetProvider {
                     .flatMap { assetGroupId ->
                         allOf(
                             TextAssetService.getAssetByGroupId(
-                                assetGroupId, category
+                                assetGroupId,
+                                category
                             ),
                             AudibleAssetDefinitionService.getAssetByGroupId(
-                                assetGroupId, category
+                                assetGroupId,
+                                category
                             )
                         ).map(assetBundler)
                     }.map { it.toOptional() } // todo: replace with `or` when on jre 11+

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/ErrorReporter.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/ErrorReporter.kt
@@ -25,7 +25,8 @@ import zd.zero.waifu.motivator.plugin.tools.RestClient
 import java.awt.Component
 import java.lang.management.ManagementFactory
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Arrays
+import java.util.Properties
 import java.util.stream.Collectors
 
 class ErrorReporter : ErrorReportSubmitter() {
@@ -34,13 +35,15 @@ class ErrorReporter : ErrorReportSubmitter() {
     companion object {
         private val gson = GsonBuilder().setPrettyPrinting().create()
         private val sentryClient: SentryClient =
-            DefaultSentryClientFactory().createSentryClient(Dsn(
-                RestClient.performGet(
-                    "https://jetbrains.assets.unthrottled.io/waifu-motivator/sentry-dsn.txt"
+            DefaultSentryClientFactory().createSentryClient(
+                Dsn(
+                    RestClient.performGet(
+                        "https://jetbrains.assets.unthrottled.io/waifu-motivator/sentry-dsn.txt"
+                    )
+                        .map { it.trim() }
+                        .orElse("https://3630573c245444f8b49ef498b24d1405@o403546.ingest.sentry.io/5374288?maxmessagelength=50000")
                 )
-                    .map { it.trim() }
-                    .orElse("https://3630573c245444f8b49ef498b24d1405@o403546.ingest.sentry.io/5374288?maxmessagelength=50000")
-            ))
+            )
     }
 
     override fun submit(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/integrations/MoodStatusBarWidget.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/integrations/MoodStatusBarWidget.kt
@@ -33,19 +33,28 @@ class MoodStatusBarWidget(private val project: Project) :
     private val connect = ApplicationManager.getApplication().messageBus.connect()
 
     init {
-        connect.subscribe(LafManagerListener.TOPIC, LafManagerListener {
-            updateWidget()
-        })
-        connect.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object : PluginSettingsListener {
-            override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
+        connect.subscribe(
+            LafManagerListener.TOPIC,
+            LafManagerListener {
                 updateWidget()
             }
-        })
-        connect.subscribe(EMOTION_TOPIC, object : MoodListener {
-            override fun onDerivedMood(currentMood: Mood) {
-                updateWidget()
+        )
+        connect.subscribe(
+            PluginSettingsListener.PLUGIN_SETTINGS_TOPIC,
+            object : PluginSettingsListener {
+                override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
+                    updateWidget()
+                }
             }
-        })
+        )
+        connect.subscribe(
+            EMOTION_TOPIC,
+            object : MoodListener {
+                override fun onDerivedMood(currentMood: Mood) {
+                    updateWidget()
+                }
+            }
+        )
         StartupManager.getInstance(project).runWhenProjectIsInitialized { updateWidget() }
     }
 
@@ -95,11 +104,14 @@ class MoodStatusBarWidget(private val project: Project) :
     }
 
     override fun getClickConsumer(): Consumer<MouseEvent> = Consumer {
-        ApplicationManager.getApplication().invokeLater({
-            ShowSettingsUtil.getInstance().showSettingsDialog(
-                project,
-                WaifuMotivatorSettingsPage::class.java
-            )
-        }, ModalityState.NON_MODAL)
+        ApplicationManager.getApplication().invokeLater(
+            {
+                ShowSettingsUtil.getInstance().showSettingsDialog(
+                    project,
+                    WaifuMotivatorSettingsPage::class.java
+                )
+            },
+            ModalityState.NON_MODAL
+        )
     }
 }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/ExitCodeListener.kt
@@ -32,26 +32,32 @@ class ExitCodeListener(private val project: Project) : Runnable, Disposable {
     private var allowedExitCodes = WaifuMotivatorPluginState.getPluginState()
         .allowedExitCodes.toExitCodes()
     init {
-        messageBus.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object : PluginSettingsListener {
-            override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
-                allowedExitCodes = newPluginState
-                    .allowedExitCodes.toExitCodes()
-            }
-        })
-
-        messageBus.subscribe(ExecutionManager.EXECUTION_TOPIC, object : ExecutionListener {
-            override fun processTerminated(
-                executorId: String,
-                env: ExecutionEnvironment,
-                handler: ProcessHandler,
-                exitCode: Int
-            ) {
-                log.debug("Observed exit code of $exitCode")
-                if (allowedExitCodes.contains(exitCode).not() && env.project == project) {
-                    run()
+        messageBus.subscribe(
+            PluginSettingsListener.PLUGIN_SETTINGS_TOPIC,
+            object : PluginSettingsListener {
+                override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
+                    allowedExitCodes = newPluginState
+                        .allowedExitCodes.toExitCodes()
                 }
             }
-        })
+        )
+
+        messageBus.subscribe(
+            ExecutionManager.EXECUTION_TOPIC,
+            object : ExecutionListener {
+                override fun processTerminated(
+                    executorId: String,
+                    env: ExecutionEnvironment,
+                    handler: ProcessHandler,
+                    exitCode: Int
+                ) {
+                    log.debug("Observed exit code of $exitCode")
+                    if (allowedExitCodes.contains(exitCode).not() && env.project == project) {
+                        run()
+                    }
+                }
+            }
+        )
     }
 
     override fun dispose() {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/listeners/IdleEventListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/listeners/IdleEventListener.kt
@@ -20,17 +20,21 @@ class IdleEventListener(private val project: Project) : Runnable, Disposable {
 
     init {
         val self = this
-        messageBus.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object : PluginSettingsListener {
-            override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
-                IdeEventQueue.getInstance().removeIdleListener(self)
-                IdeEventQueue.getInstance().addIdleListener(self,
-                    TimeUnit.MILLISECONDS.convert(
-                        newPluginState.idleTimeoutInMinutes,
-                        TimeUnit.MINUTES
-                    ).toInt()
-                )
+        messageBus.subscribe(
+            PluginSettingsListener.PLUGIN_SETTINGS_TOPIC,
+            object : PluginSettingsListener {
+                override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
+                    IdeEventQueue.getInstance().removeIdleListener(self)
+                    IdeEventQueue.getInstance().addIdleListener(
+                        self,
+                        TimeUnit.MILLISECONDS.convert(
+                            newPluginState.idleTimeoutInMinutes,
+                            TimeUnit.MINUTES
+                        ).toInt()
+                    )
+                }
             }
-        })
+        )
         IdeEventQueue.getInstance().addIdleListener(
             this,
             TimeUnit.MILLISECONDS.convert(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/motivation/BaseMotivation.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/motivation/BaseMotivation.kt
@@ -45,18 +45,24 @@ abstract class BaseMotivation(
     override fun displayNotification() {
         val notification = notifier.createNotification()
         notification.balloon.toOptional().ifPresent {
-            it.addListener(object : JBPopupListener {
-                override fun onClosed(event: LightweightWindowEvent) {
-                    onAlertClosed(notification)
+            it.addListener(
+                object : JBPopupListener {
+                    override fun onClosed(event: LightweightWindowEvent) {
+                        onAlertClosed(notification)
+                    }
                 }
-            })
+            )
         }
     }
 
     override fun isDistractionAllowed(): Boolean =
-        !(WaifuMotivatorPluginState.getInstance().state?.isDisabledInDistractionFreeMode ?: true &&
-            (Registry.get(KEY_DISTRACTION_FREE_MODE).asBoolean() ||
-            UISettings.instance.presentationMode))
+        !(
+            WaifuMotivatorPluginState.getInstance().state?.isDisabledInDistractionFreeMode ?: true &&
+                (
+                    Registry.get(KEY_DISTRACTION_FREE_MODE).asBoolean() ||
+                        UISettings.instance.presentationMode
+                    )
+            )
 
     override fun onAlertClosed(notification: Notification) {
         val duration = System.currentTimeMillis() - notification.timestamp

--- a/src/main/java/zd/zero/waifu/motivator/plugin/motivation/MotivationFactory.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/motivation/MotivationFactory.kt
@@ -18,7 +18,9 @@ object MotivationFactory {
         motivationEvent: MotivationEvent,
         waifuAssetCategory: WaifuAssetCategory
     ) = showMotivationEventForCategory(
-        motivationEvent, waifuAssetCategory, defaultListener
+        motivationEvent,
+        waifuAssetCategory,
+        defaultListener
     )
 
     fun showMotivationEventFromCategories(
@@ -26,21 +28,25 @@ object MotivationFactory {
         vararg waifuAssetCategory: WaifuAssetCategory,
         lifecycleListener: MotivationLifecycleListener = defaultListener
     ) = showMotivationFromMultipleCategories(
-        motivationEvent, lifecycleListener, waifuAssetCategory
+        motivationEvent,
+        lifecycleListener,
+        waifuAssetCategory
     ) { motivationAsset: MotivationAsset ->
-            VisualMotivationFactory.constructMotivation(
-                motivationEvent.project,
-                motivationAsset,
-                motivationEvent.alertConfigurationSupplier()
-            )
-        }
+        VisualMotivationFactory.constructMotivation(
+            motivationEvent.project,
+            motivationAsset,
+            motivationEvent.alertConfigurationSupplier()
+        )
+    }
 
     fun showUntitledMotivationEventFromCategories(
         motivationEvent: MotivationEvent,
         vararg waifuAssetCategory: WaifuAssetCategory,
         lifecycleListener: MotivationLifecycleListener = defaultListener
     ) = showMotivationFromMultipleCategories(
-        motivationEvent, lifecycleListener, waifuAssetCategory
+        motivationEvent,
+        lifecycleListener,
+        waifuAssetCategory
     ) { motivationAsset: MotivationAsset ->
         VisualMotivationFactory.constructNonTitledMotivation(
             motivationEvent.project,

--- a/src/main/java/zd/zero/waifu/motivator/plugin/motivation/VisualMotivation.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/motivation/VisualMotivation.kt
@@ -1,7 +1,7 @@
 package zd.zero.waifu.motivator.plugin.motivation
 
-import zd.zero.waifu.motivator.plugin.alert.WaifuNotification
 import zd.zero.waifu.motivator.plugin.alert.AlertConfiguration
+import zd.zero.waifu.motivator.plugin.alert.WaifuNotification
 import zd.zero.waifu.motivator.plugin.player.WaifuSoundPlayer
 
 class VisualMotivation(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/motivation/event/MotivationEventListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/motivation/event/MotivationEventListener.kt
@@ -6,8 +6,8 @@ interface MotivationEventListener {
 
     companion object {
         val TOPIC: Topic<MotivationEventListener> = Topic.create(
-                "Motivation Events",
-                MotivationEventListener::class.java
+            "Motivation Events",
+            MotivationEventListener::class.java
         )
     }
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UpdateNotification.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UpdateNotification.kt
@@ -1,6 +1,10 @@
 package zd.zero.waifu.motivator.plugin.onboarding
 
-import com.intellij.notification.*
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationDisplayType
+import com.intellij.notification.NotificationGroup
+import com.intellij.notification.NotificationListener
+import com.intellij.notification.NotificationType
 import com.intellij.notification.impl.NotificationsManagerImpl
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.popup.Balloon
@@ -11,7 +15,8 @@ import zd.zero.waifu.motivator.plugin.WaifuMotivator.PLUGIN_NAME
 import zd.zero.waifu.motivator.plugin.onboarding.BalloonTools.fetchBalloonParameters
 import zd.zero.waifu.motivator.plugin.service.ApplicationService
 
-val UPDATE_MESSAGE: String = """
+val UPDATE_MESSAGE: String =
+    """
       What's New?<br>
       <ul>
         <li>Added reactions to: exit code, build, and idle events.</li>
@@ -27,7 +32,7 @@ val UPDATE_MESSAGE: String = """
       <br><br>
       Want more of your Waifu?<br>
       Make a request for <a href="https://github.com/zd-zero/waifu-motivator-plugin/projects/3">more assets of your Waifu!</a>
-""".trimIndent()
+    """.trimIndent()
 
 object UpdateNotification {
 
@@ -74,7 +79,8 @@ object UpdateNotification {
         listener: NotificationListener? = defaultListener
     ) {
         notificationGroup.createNotification(
-            title, content,
+            title,
+            content,
             listener = listener
         ).setIcon(WaifuMotivatorIcons.MENU)
             .notify(project)

--- a/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UserOnboarding.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/onboarding/UserOnboarding.kt
@@ -8,7 +8,8 @@ import zd.zero.waifu.motivator.plugin.WaifuMotivator
 import zd.zero.waifu.motivator.plugin.platform.UpdateAssetsListener
 import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorPluginState
 import zd.zero.waifu.motivator.plugin.tools.toOptional
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 object UserOnboarding {
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/ResetCore.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/ResetCore.kt
@@ -13,16 +13,18 @@ class ResetCore {
 
     fun processMutationEvent(emotionalMutationAction: EmotionalMutationAction) {
         MotivationFactory.showUntitledMotivationEventFromCategories(
-                MotivationEvent(MotivationEvents.MISC,
-                        MotivationEventCategory.NEUTRAL,
-                        "Relax Acknowledgment",
-                        emotionalMutationAction.project ?: ProjectManager.getInstance().openProjects.first()) {
-                    AlertConfiguration(
-                            isAlertEnabled = true,
-                            isDisplayNotificationEnabled = true,
-                            isSoundAlertEnabled = false
-                    )
-                },
+            MotivationEvent(
+                MotivationEvents.MISC,
+                MotivationEventCategory.NEUTRAL,
+                "Relax Acknowledgment",
+                emotionalMutationAction.project ?: ProjectManager.getInstance().openProjects.first()
+            ) {
+                AlertConfiguration(
+                    isAlertEnabled = true,
+                    isDisplayNotificationEnabled = true,
+                    isSoundAlertEnabled = false
+                )
+            },
             WaifuAssetCategory.ACKNOWLEDGEMENT,
             WaifuAssetCategory.ACKNOWLEDGEMENT,
             WaifuAssetCategory.ACKNOWLEDGEMENT,

--- a/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/TaskPersonalityCore.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/TaskPersonalityCore.kt
@@ -33,7 +33,8 @@ class TaskPersonalityCore : PersonalityCore {
         return when (mood) {
             Mood.SMUG -> WaifuAssetCategory.SMUG.toArray()
             Mood.HAPPY -> arrayOf(
-                WaifuAssetCategory.CELEBRATION, WaifuAssetCategory.HAPPY
+                WaifuAssetCategory.CELEBRATION,
+                WaifuAssetCategory.HAPPY
             )
             else -> WaifuAssetCategory.CELEBRATION.toArray()
         }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/CoolDownCore.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/CoolDownCore.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.Disposable
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.util.Alarm
 import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionalMutationType.COOL_DOWN
-import zd.zero.waifu.motivator.plugin.personality.core.emotions.MoodCategory.*
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.MoodCategory.NEGATIVE
 import java.util.concurrent.TimeUnit
 
 internal enum class CoolDownStatus {
@@ -41,13 +41,14 @@ class CoolDownCore : MoodListener, Disposable {
 
     private fun registerCoolDownEvent() {
         coolDownAlarm.addRequest(
-                {
-                    ApplicationManager.getApplication().messageBus
-                        .syncPublisher(EMOTIONAL_MUTATION_TOPIC)
-                        .onAction(EmotionalMutationAction(COOL_DOWN, NEGATIVE))
-                },
+            {
+                ApplicationManager.getApplication().messageBus
+                    .syncPublisher(EMOTIONAL_MUTATION_TOPIC)
+                    .onAction(EmotionalMutationAction(COOL_DOWN, NEGATIVE))
+            },
             TimeUnit.MILLISECONDS.convert(
-                COOL_DOWN_DURATION_IN_MINUTES, TimeUnit.MINUTES
+                COOL_DOWN_DURATION_IN_MINUTES,
+                TimeUnit.MINUTES
             )
         )
     }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/EmotionCore.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/EmotionCore.kt
@@ -10,13 +10,16 @@ class EmotionCore(
     private val random: Random = Random(Random(System.currentTimeMillis()).nextLong())
 ) {
     private val negativeDerivationUnit = NegativeEmotionDerivationUnit(
-        pluginState, random
+        pluginState,
+        random
     )
     private val positiveDerivationUnit = PositiveEmotionDerivationUnit(
-        pluginState, random
+        pluginState,
+        random
     )
     private val neutralDerivationUnit = NeutralEmotionDerivationUnit(
-        pluginState, random
+        pluginState,
+        random
     )
     private var emotionalState = EmotionalState(Mood.CALM)
 
@@ -54,10 +57,10 @@ class EmotionCore(
     private fun processMutation(
         emotionalMutationAction: EmotionalMutationAction
     ) = when (emotionalMutationAction.moodCategory) {
-            MoodCategory.POSITIVE -> positiveDerivationUnit.deriveFromMutation(emotionalMutationAction, emotionalState)
-            MoodCategory.NEGATIVE -> negativeDerivationUnit.deriveFromMutation(emotionalMutationAction, emotionalState)
-            MoodCategory.NEUTRAL -> neutralDerivationUnit.deriveFromMutation(emotionalMutationAction, emotionalState)
-        }
+        MoodCategory.POSITIVE -> positiveDerivationUnit.deriveFromMutation(emotionalMutationAction, emotionalState)
+        MoodCategory.NEGATIVE -> negativeDerivationUnit.deriveFromMutation(emotionalMutationAction, emotionalState)
+        MoodCategory.NEUTRAL -> neutralDerivationUnit.deriveFromMutation(emotionalMutationAction, emotionalState)
+    }
 
     private fun deriveAndPersistEmotionalState(stateSupplier: () -> EmotionalState): Mood {
         emotionalState = stateSupplier()

--- a/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/NegativeEmotionDerivationUnit.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/NegativeEmotionDerivationUnit.kt
@@ -16,7 +16,8 @@ internal class NegativeEmotionDerivationUnit(
 
     companion object {
         val OTHER_NEGATIVE_EMOTIONS = listOf(
-            Mood.SHOCKED, Mood.DISAPPOINTED
+            Mood.SHOCKED,
+            Mood.DISAPPOINTED
         )
     }
 
@@ -70,22 +71,22 @@ internal class NegativeEmotionDerivationUnit(
 
     private fun pickNegativeMood(observedFrustrationEvents: Int) =
         when {
-        shouldBeEnraged(observedFrustrationEvents) ->
-            hurryFindCover()
+            shouldBeEnraged(observedFrustrationEvents) ->
+                hurryFindCover()
 
-        shouldBeFrustrated(observedFrustrationEvents) ->
-            tryToRemainCalm()
+            shouldBeFrustrated(observedFrustrationEvents) ->
+                tryToRemainCalm()
 
-        // todo: more appropriate choice based off of previous state
-        else -> OTHER_NEGATIVE_EMOTIONS.random(random)
-    }
+            // todo: more appropriate choice based off of previous state
+            else -> OTHER_NEGATIVE_EMOTIONS.random(random)
+        }
 
     private fun shouldBeFrustrated(observedFrustrationEvents: Int) =
         pluginState.isAllowFrustration &&
             pluginState.eventsBeforeFrustration <= observedFrustrationEvents
 
     private fun hasCalmedDown(observedFrustrationEvents: Int) =
-            pluginState.eventsBeforeFrustration / 2 >= observedFrustrationEvents
+        pluginState.eventsBeforeFrustration / 2 >= observedFrustrationEvents
 
     private fun shouldBeEnraged(observedFrustrationEvents: Int) =
         shouldBeFrustrated(observedFrustrationEvents) &&
@@ -96,7 +97,8 @@ internal class NegativeEmotionDerivationUnit(
         val primaryEmotions =
             Stream.of(
                 Mood.ENRAGED to rageProbability,
-                Mood.FRUSTRATED to pluginState.probabilityOfFrustration - rageProbability)
+                Mood.FRUSTRATED to pluginState.probabilityOfFrustration - rageProbability
+            )
 
         return pickNegativeEmotion(primaryEmotions)
     }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/PositiveEmotionDerivationUnit.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/personality/core/emotions/PositiveEmotionDerivationUnit.kt
@@ -3,8 +3,8 @@ package zd.zero.waifu.motivator.plugin.personality.core.emotions
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEventCategory
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvents
-import zd.zero.waifu.motivator.plugin.tools.ProbabilityTools
 import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorState
+import zd.zero.waifu.motivator.plugin.tools.ProbabilityTools
 import java.util.stream.Stream
 import kotlin.random.Random
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/service/WaifuGatekeeper.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/service/WaifuGatekeeper.kt
@@ -24,11 +24,14 @@ class WaifuGatekeeper : Disposable {
             .toSet()
 
     init {
-        connection.subscribe(PluginSettingsListener.PLUGIN_SETTINGS_TOPIC, object : PluginSettingsListener {
-            override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
-                allowedWaifu = extractAllowedCharactersFromState(newPluginState)
+        connection.subscribe(
+            PluginSettingsListener.PLUGIN_SETTINGS_TOPIC,
+            object : PluginSettingsListener {
+                override fun settingsUpdated(newPluginState: WaifuMotivatorState) {
+                    allowedWaifu = extractAllowedCharactersFromState(newPluginState)
+                }
             }
-        })
+        )
     }
 
     fun isAllowed(characters: List<String>?): Boolean =

--- a/src/main/java/zd/zero/waifu/motivator/plugin/settings/PluginSettingsListener.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/settings/PluginSettingsListener.kt
@@ -1,7 +1,7 @@
 package zd.zero.waifu.motivator.plugin.settings
 
 import com.intellij.util.messages.Topic
-import java.util.*
+import java.util.EventListener
 
 interface PluginSettingsListener : EventListener {
     companion object {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/AssetTools.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/AssetTools.kt
@@ -3,7 +3,7 @@ package zd.zero.waifu.motivator.plugin.tools
 import zd.zero.waifu.motivator.plugin.assets.MotivationAsset
 import zd.zero.waifu.motivator.plugin.assets.VisualMotivationAssetProvider
 import zd.zero.waifu.motivator.plugin.assets.WaifuAssetCategory
-import java.util.*
+import java.util.Optional
 
 object AssetTools {
 

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/Debouncer.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/Debouncer.kt
@@ -2,7 +2,7 @@ package zd.zero.waifu.motivator.plugin.tools
 
 import com.intellij.openapi.Disposable
 import com.intellij.util.Alarm
-import java.util.*
+import java.util.LinkedList
 
 interface Debouncer {
     fun debounce(toDebounce: () -> Unit)
@@ -14,7 +14,8 @@ interface BufferedDebouncer<T> {
 
 class AlarmDebouncer<T>(private val interval: Int) :
     Debouncer,
-    BufferedDebouncer<T>, Disposable {
+    BufferedDebouncer<T>,
+    Disposable {
     private val alarm: Alarm = Alarm()
 
     @Volatile
@@ -31,10 +32,13 @@ class AlarmDebouncer<T>(private val interval: Int) :
     override fun debounceAndBuffer(t: T, onDebounced: (List<T>) -> Unit) {
         performDebounce({
             buffer.add(t)
-            alarm.addRequest({
-                onDebounced(buffer.toMutableList())
-                buffer.clear()
-            }, interval)
+            alarm.addRequest(
+                {
+                    onDebounced(buffer.toMutableList())
+                    buffer.clear()
+                },
+                interval
+            )
         }) {
             buffer.push(t)
         }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/ExceptionTools.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/ExceptionTools.kt
@@ -1,7 +1,7 @@
 package zd.zero.waifu.motivator.plugin.tools
 
 import com.intellij.openapi.diagnostic.Logger
-import java.util.*
+import java.util.Optional
 
 object ExceptionTools {
     private val log: Logger? = Logger.getInstance(ExceptionTools::class.java)

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/ProbabilityTools.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/ProbabilityTools.kt
@@ -38,8 +38,8 @@ class ProbabilityTools(
     ): List<Pair<Mood, Int>> {
         val secondaryEmotionWeights = weightRemaining / secondaryEmotions.size
         return concat(
-                primaryEmotions,
-                secondaryEmotions.stream().map { it to secondaryEmotionWeights }
+            primaryEmotions,
+            secondaryEmotions.stream().map { it to secondaryEmotionWeights }
         ).collect(Collectors.toList())
             .shuffled<Pair<Mood, Int>>()
     }

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/RestClient.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/RestClient.kt
@@ -4,7 +4,7 @@ import com.intellij.openapi.diagnostic.Logger
 import org.apache.http.client.config.RequestConfig
 import org.apache.http.client.methods.HttpGet
 import org.apache.http.impl.client.HttpClients
-import java.util.*
+import java.util.Optional
 import java.util.concurrent.TimeUnit
 
 object RestClient {

--- a/src/main/java/zd/zero/waifu/motivator/plugin/tools/ToolBox.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/tools/ToolBox.kt
@@ -1,6 +1,6 @@
 package zd.zero.waifu.motivator.plugin.tools
 
-import java.util.*
+import java.util.Optional
 import java.util.function.Consumer
 
 fun <T, U, S> allOf(
@@ -15,6 +15,7 @@ fun <T, U, S> allOf(
             }
         }
     }
+
 fun <T, U> allOf(
     o1: Optional<T>,
     o2: Optional<U>

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
@@ -9,7 +9,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
 import org.junit.Test
 import zd.zero.waifu.motivator.plugin.tools.toOptional
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 internal class FakeVisualAssetDefinitionService(
     assetManager: RemoteAssetManager<VisualMotivationAssetDefinition, VisualMotivationAsset>

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManagerTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManagerTest.kt
@@ -1,6 +1,11 @@
 package zd.zero.waifu.motivator.plugin.assets
 
-import io.mockk.*
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.unmockkObject
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.AfterClass
 import org.junit.BeforeClass
@@ -10,7 +15,7 @@ import zd.zero.waifu.motivator.plugin.platform.UpdateAssetsListener
 import zd.zero.waifu.motivator.plugin.test.tools.TestTools
 import zd.zero.waifu.motivator.plugin.tools.toOptional
 import java.nio.file.Paths
-import java.util.*
+import java.util.Optional
 
 internal class FakeAssetManager :
     RemoteAssetManager<VisualMotivationAssetDefinition, VisualMotivationAsset>(

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/TextAssetServiceTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/TextAssetServiceTest.kt
@@ -6,13 +6,12 @@ import io.mockk.unmockkObject
 import io.mockk.verify
 import org.assertj.core.api.Assertions
 import org.junit.AfterClass
-import org.junit.Test
-
 import org.junit.BeforeClass
+import org.junit.Test
 import zd.zero.waifu.motivator.plugin.test.tools.TestTools
 import zd.zero.waifu.motivator.plugin.tools.toOptional
 import java.nio.file.Paths
-import java.util.*
+import java.util.UUID
 
 class TextAssetServiceTest {
 

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProviderTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/VisualMotivationAssetProviderTest.kt
@@ -10,7 +10,8 @@ import org.junit.Test
 import zd.zero.waifu.motivator.plugin.test.tools.TestTools
 import zd.zero.waifu.motivator.plugin.tools.toOptional
 import java.nio.file.Paths
-import java.util.*
+import java.util.Optional
+import java.util.UUID
 
 class VisualMotivationAssetProviderTest {
 
@@ -102,16 +103,22 @@ class VisualMotivationAssetProviderTest {
                 ImageDimension(69, 420),
                 groupId
             ).toOptional()
-        every { TextAssetService.getAssetByGroupId(
-            groupId, WaifuAssetCategory.MOCKING
-        ) } returns TextualMotivationAsset("O Kawaii Koto").toOptional()
-        every { AudibleAssetDefinitionService.getAssetByGroupId(
-            groupId, WaifuAssetCategory.MOCKING
-        ) } returns AudibleMotivationAsset(Paths.get("/o_kawaii_koto.mp3")).toOptional()
+        every {
+            TextAssetService.getAssetByGroupId(
+                groupId,
+                WaifuAssetCategory.MOCKING
+            )
+        } returns TextualMotivationAsset("O Kawaii Koto").toOptional()
+        every {
+            AudibleAssetDefinitionService.getAssetByGroupId(
+                groupId,
+                WaifuAssetCategory.MOCKING
+            )
+        } returns AudibleMotivationAsset(Paths.get("/o_kawaii_koto.mp3")).toOptional()
 
         val maybeMotivationAsset =
             VisualMotivationAssetProvider.createAssetByCategory(WaifuAssetCategory.MOCKING)
-            .get()
+                .get()
 
         assertThat(maybeMotivationAsset.title).contains("O Kawaii Koto")
         assertThat(maybeMotivationAsset.soundFilePath).isEqualTo(Paths.get("/o_kawaii_koto.mp3"))
@@ -128,12 +135,18 @@ class VisualMotivationAssetProviderTest {
                 ImageDimension(69, 420),
                 groupId
             ).toOptional()
-        every { TextAssetService.getAssetByGroupId(
-            groupId, WaifuAssetCategory.MOCKING
-        ) } returns Optional.empty()
-        every { AudibleAssetDefinitionService.getAssetByGroupId(
-            groupId, WaifuAssetCategory.MOCKING
-        ) } returns AudibleMotivationAsset(Paths.get("/o_kawaii_koto.mp3")).toOptional()
+        every {
+            TextAssetService.getAssetByGroupId(
+                groupId,
+                WaifuAssetCategory.MOCKING
+            )
+        } returns Optional.empty()
+        every {
+            AudibleAssetDefinitionService.getAssetByGroupId(
+                groupId,
+                WaifuAssetCategory.MOCKING
+            )
+        } returns AudibleMotivationAsset(Paths.get("/o_kawaii_koto.mp3")).toOptional()
 
         assertThat(
             VisualMotivationAssetProvider.createAssetByCategory(WaifuAssetCategory.MOCKING)
@@ -151,12 +164,18 @@ class VisualMotivationAssetProviderTest {
                 ImageDimension(69, 420),
                 groupId
             ).toOptional()
-        every { TextAssetService.getAssetByGroupId(
-            groupId, WaifuAssetCategory.MOCKING
-        ) } returns TextualMotivationAsset("O Kawaii Koto").toOptional()
-        every { AudibleAssetDefinitionService.getAssetByGroupId(
-            groupId, WaifuAssetCategory.MOCKING
-        ) } returns Optional.empty()
+        every {
+            TextAssetService.getAssetByGroupId(
+                groupId,
+                WaifuAssetCategory.MOCKING
+            )
+        } returns TextualMotivationAsset("O Kawaii Koto").toOptional()
+        every {
+            AudibleAssetDefinitionService.getAssetByGroupId(
+                groupId,
+                WaifuAssetCategory.MOCKING
+            )
+        } returns Optional.empty()
 
         assertThat(
             VisualMotivationAssetProvider.createAssetByCategory(WaifuAssetCategory.MOCKING)

--- a/src/test/java/zd/zero/waifu/motivator/plugin/personality/NegativeEmotionCoreTests.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/personality/NegativeEmotionCoreTests.kt
@@ -9,7 +9,11 @@ import zd.zero.waifu.motivator.plugin.alert.AlertConfiguration
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvent
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEventCategory
 import zd.zero.waifu.motivator.plugin.motivation.event.MotivationEvents
-import zd.zero.waifu.motivator.plugin.personality.core.emotions.*
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionCore
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionalMutationAction
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.EmotionalMutationType
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.Mood
+import zd.zero.waifu.motivator.plugin.personality.core.emotions.MoodCategory
 import zd.zero.waifu.motivator.plugin.personality.core.emotions.NegativeEmotionDerivationUnit.Companion.OTHER_NEGATIVE_EMOTIONS
 import zd.zero.waifu.motivator.plugin.settings.WaifuMotivatorState
 import zd.zero.waifu.motivator.plugin.tools.toList

--- a/src/test/java/zd/zero/waifu/motivator/plugin/tools/ToolBoxKtTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/tools/ToolBoxKtTest.kt
@@ -2,7 +2,7 @@ package zd.zero.waifu.motivator.plugin.tools
 
 import org.assertj.core.api.Assertions
 import org.junit.Test
-import java.util.*
+import java.util.Optional
 
 internal class BestGirl(val name: String)
 class ToolBoxKtTest {


### PR DESCRIPTION
This PR bump the ktlint to `9.4.1` and performed the `ktlintFormat` and turns out that it hates star imports so added a project Kotlin code style to prevent the usage of star imports.