### PR TITLE
fix: handling malformed definitions better

### DIFF
--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetModels.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/AssetModels.kt
@@ -7,6 +7,9 @@ interface AssetDefinition {
     val categories: List<WaifuAssetCategory>
     val path: String
     val groupId: UUID?
+
+    fun isValid(): Boolean =
+        !(path.isNullOrBlank() || categories.isNullOrEmpty())
 }
 
 interface Asset {
@@ -16,10 +19,12 @@ interface Asset {
 data class ImageDimension(
     val width: Int,
     val height: Int
-)
+) {
+    fun isValid(): Boolean =
+        width > 0 && height > 0
+}
 
 data class VisualMotivationAssetDefinition(
-    val imagePath: String, // todo: remove this once migrated
     override val path: String,
     val imageAlt: String,
     val imageDimensions: ImageDimension,
@@ -35,6 +40,10 @@ data class VisualMotivationAssetDefinition(
             groupId,
             characters
         )
+
+    override fun isValid(): Boolean =
+        super.isValid() && imageAlt != null &&
+            imageDimensions?.isValid()
 }
 
 data class VisualMotivationAsset(

--- a/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
+++ b/src/main/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetManager.kt
@@ -91,6 +91,7 @@ abstract class RemoteAssetManager<T : AssetDefinition, U : Asset>(
                 .flatMap {
                     convertToDefinitions(it)
                 }
+                .map { it.filter { assetDefinition -> assetDefinition.isValid() } }
         } catch (e: Throwable) {
             log.error("Unable to initialize asset metadata.", e)
             Optional.empty()

--- a/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
+++ b/src/test/java/zd/zero/waifu/motivator/plugin/assets/RemoteAssetDefinitionServiceTest.kt
@@ -53,7 +53,6 @@ class RemoteAssetDefinitionServiceTest {
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
@@ -76,14 +75,12 @@ class RemoteAssetDefinitionServiceTest {
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf(
             VisualMotivationAssetDefinition(
-                "Ryuko Waiting",
                 "Ryuko Waiting",
                 "Best Girl",
                 ImageDimension(69, 420),
@@ -107,7 +104,6 @@ class RemoteAssetDefinitionServiceTest {
     fun `get random asset by category should return empty when unable to fetch remote asset with no local assets`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
@@ -128,7 +124,6 @@ class RemoteAssetDefinitionServiceTest {
     @Test
     fun `get random asset by category should return remote when available`() {
         val bestMotivation = VisualMotivationAssetDefinition(
-            "Ryuko",
             "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
@@ -153,14 +148,12 @@ class RemoteAssetDefinitionServiceTest {
     fun `get random asset by category should return random remote when preferred remote asset is not available`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
         )
         every { remoteAssetManager.supplyRemoteAssetDefinitions() } returns listOf(
             VisualMotivationAssetDefinition(
-                "Ryuko Disappointed",
                 "Ryuko Disappointed",
                 "Best Girl",
                 ImageDimension(69, 420),
@@ -171,7 +164,6 @@ class RemoteAssetDefinitionServiceTest {
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf(
             VisualMotivationAssetDefinition(
                 "Ryuko Waiting",
-                "Ryuko Waiting",
                 "Best Girl",
                 ImageDimension(69, 420),
                 listOf(WaifuAssetCategory.WAITING)
@@ -179,7 +171,6 @@ class RemoteAssetDefinitionServiceTest {
         )
         every { remoteAssetManager.supplyAllLocalAssetDefinitions() } returns setOf(
             VisualMotivationAssetDefinition(
-                "Ryuko Frustrated",
                 "Ryuko Frustrated",
                 "Best Girl",
                 ImageDimension(69, 420),
@@ -201,7 +192,6 @@ class RemoteAssetDefinitionServiceTest {
     fun `get random asset by category should return empty when unable to fetch remote asset with no matching local assets`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
@@ -213,7 +203,6 @@ class RemoteAssetDefinitionServiceTest {
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
         val garbageWaifu = VisualMotivationAssetDefinition(
-            "Trash Chan",
             "Trash Chan",
             "Literal Garbage",
             ImageDimension(42, 9001),
@@ -232,7 +221,6 @@ class RemoteAssetDefinitionServiceTest {
     fun `get random asset by category should return empty when local asset is not local`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
@@ -240,7 +228,6 @@ class RemoteAssetDefinitionServiceTest {
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
-            "Local Ryuko",
             "Local Ryuko",
             "Global Best Girl",
             ImageDimension(69, 420),
@@ -260,7 +247,6 @@ class RemoteAssetDefinitionServiceTest {
     fun `get random asset by category should return local asset remote asset is not available`() {
         val bestMotivation = VisualMotivationAssetDefinition(
             "Ryuko",
-            "Ryuko",
             "Best Girl",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION)
@@ -268,7 +254,6 @@ class RemoteAssetDefinitionServiceTest {
         every { remoteAssetManager.resolveAsset(bestMotivation) } returns Optional.empty()
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
-            "Local Ryuko",
             "Local Ryuko",
             "Global Best Girl",
             ImageDimension(69, 420),
@@ -291,7 +276,6 @@ class RemoteAssetDefinitionServiceTest {
         val groupId = UUID.randomUUID()
 
         val bestLocalMotivation = VisualMotivationAssetDefinition(
-            "Local Ishtar",
             "Local Ishtar",
             "Global Goddess",
             ImageDimension(69, 420),
@@ -317,7 +301,6 @@ class RemoteAssetDefinitionServiceTest {
 
         val notTheMotivationYouAreLookingFor = VisualMotivationAssetDefinition(
             "Local Aqua",
-            "Local Aqua",
             "Aqua",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION),
@@ -326,7 +309,6 @@ class RemoteAssetDefinitionServiceTest {
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf(notTheMotivationYouAreLookingFor)
 
         val remoteAsset = VisualMotivationAssetDefinition(
-            "Local Ishtar",
             "Local Ishtar",
             "Global Goddess",
             ImageDimension(69, 420),
@@ -352,7 +334,6 @@ class RemoteAssetDefinitionServiceTest {
 
         val notTheMotivationYouAreLookingFor = VisualMotivationAssetDefinition(
             "Local Aqua",
-            "Local Aqua",
             "Aqua",
             ImageDimension(69, 420),
             listOf(WaifuAssetCategory.MOTIVATION),
@@ -361,7 +342,6 @@ class RemoteAssetDefinitionServiceTest {
         every { remoteAssetManager.supplyLocalAssetDefinitions() } returns setOf(notTheMotivationYouAreLookingFor)
 
         val remoteAsset = VisualMotivationAssetDefinition(
-            "Local Ishtar",
             "Local Ishtar",
             "Global Goddess",
             ImageDimension(69, 420),

--- a/src/test/resources/visuals/assets.json
+++ b/src/test/resources/visuals/assets.json
@@ -1,6 +1,19 @@
 [
     {
-        "imagePath": "waiting/kanna_bored.gif",
+        "not": "a",
+        "valid": "definition"
+    },
+    {
+        "path": "should/not/show/up",
+        "imageAlt": "",
+        "imageDimensions": {
+        },
+        "categories": [
+            "WAITING",
+            "BORED"
+        ]
+    },
+    {
         "path": "waiting/kanna_bored.gif",
         "imageAlt": "",
         "imageDimensions": {
@@ -13,7 +26,6 @@
         ]
     },
     {
-        "imagePath": "waiting/konata_bored_one.gif",
         "path": "waiting/konata_bored_one.gif",
         "imageAlt": "",
         "imageDimensions": {
@@ -26,7 +38,6 @@
         ]
     },
     {
-        "imagePath": "waiting/misato_bored_one.gif",
         "path": "waiting/misato_bored_one.gif",
         "imageAlt": "",
         "imageDimensions": {
@@ -39,7 +50,6 @@
         ]
     },
     {
-        "imagePath": "waiting/ryuko_waiting.gif",
         "path": "waiting/ryuko_waiting.gif",
         "imageAlt": "",
         "imageDimensions": {

--- a/src/test/resources/visuals/updated-assets.json
+++ b/src/test/resources/visuals/updated-assets.json
@@ -1,6 +1,19 @@
 [
     {
-        "imagePath": "aqua_celebration.gif",
+        "not": "a",
+        "valid": "definition"
+    },
+    {
+        "path": "should/not/show/up",
+        "imageAlt": "",
+        "imageDimensions": {
+        },
+        "categories": [
+            "WAITING",
+            "BORED"
+        ]
+    },
+    {
         "path": "aqua_celebration.gif",
         "imageAlt": "Aqua celebration",
         "imageDimensions": {
@@ -13,7 +26,6 @@
         ]
     },
     {
-        "imagePath": "celebration/caramelldansen.gif",
         "path": "celebration/caramelldansen.gif",
         "imageAlt": "Caramelldansen",
         "imageDimensions": {
@@ -26,7 +38,6 @@
         ]
     },
     {
-        "imagePath": "waiting/kanna_bored.gif",
         "path": "waiting/kanna_bored.gif",
         "imageAlt": "",
         "imageDimensions": {
@@ -39,7 +50,6 @@
         ]
     },
     {
-        "imagePath": "waiting/konata_bored_one.gif",
         "path": "waiting/konata_bored_one.gif",
         "imageAlt": "",
         "imageDimensions": {
@@ -52,7 +62,6 @@
         ]
     },
     {
-        "imagePath": "waiting/misato_bored_one.gif",
         "path": "waiting/misato_bored_one.gif",
         "imageAlt": "",
         "imageDimensions": {
@@ -65,7 +74,6 @@
         ]
     },
     {
-        "imagePath": "waiting/ryuko_waiting.gif",
         "path": "waiting/ryuko_waiting.gif",
         "imageAlt": "",
         "imageDimensions": {


### PR DESCRIPTION
# Motivation

Closes #242 

Turns out that this was probably just an issue for me because I was probably messing around with the `assets.json` file, and broke something :sweat_smile: .

Anyways, having this in place should prevent the plugin from breaking.