### PR TITLE
docs: doki-theme integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,12 @@ Thankfully, you have the ability to configure what your waifu does via the setti
 
 ![Waifu Settings](screenshots/waifu_motivator_settings.png)
 
+## Doki-Theme Integration
+
+You can also install [Doki Theme](https://github.com/doki-theme/doki-theme-jetbrains) to have a better *Waifu* development experience!
+
+![Doki Theme](screenshots/doki-theme.gif)
+
 # Development
 
 ## Getting Started


### PR DESCRIPTION
For the `doki-theme.gif` file, I pulled it from [here.](https://github.com/doki-theme/doki-theme-jetbrains/blob/master/assets/screenshots/flagship_themes.gif) In case that it is updated, we wouldn't have any broken images in this repo. Hope that it's fine to have a copy of your gif here 🤞.